### PR TITLE
Removed unnecessary function gen(instream, outstream, errstream) definition

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -352,7 +352,7 @@ end
 
 ##
 # the main read - write method
-function gen(instream, outstream, errstream)
+function gen()
     try
         writeproto(STDOUT, generate(STDIN))
     catch ex
@@ -361,7 +361,6 @@ function gen(instream, outstream, errstream)
         exit(-1)
     end
 end
-gen()=gen(STDIN, STDOUT, STDERR)
 
 end # module Gen
 


### PR DESCRIPTION
The function definition for `function gen(instream, outstream, errstream)` was hard coding `STDIN`, `STDOUT`, and `STDERR` so I've removed that definition and changed it to the definition for `function gen()`.
