### PR TITLE
Added support for the field name type.

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -156,6 +156,12 @@ function generate(outio::IO, errio::IO, dtype::DescriptorProto, scope::Scope, ex
     fldnums = Int[]
     defvals = String[]
     for field::FieldDescriptorProto in dtype.field
+        # If we find that the field name is type change it to _type, this could
+        # probably be done for other field names that are also keywords in
+        # Julia.
+        if field.name == "type"
+            field.name = "_type"
+        end
         fldname = field.name
         if field.typ == TYPE_GROUP
             println(errio, "Groups are not supported")


### PR DESCRIPTION
Since type is a keyword in Julia we need to make sure that if the protobuf
message has a field name 'type' that we do not use that for the Julia's type
attribute name. Instead we'll replace it with '_type'.

This same solution or something similar should likely be employed for other
Julia keywords.
