### PR TITLE
Added a _pb postfix to the protoc generated Julia files.

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -321,6 +321,7 @@ function append_response(resp::CodeGeneratorResponse, protofile::FileDescriptorP
     outdir = dirname(protofile.name)
     filename = splitext(basename(protofile.name))[1]
     filename = replace(filename, '.', '_')
+    filename = string(filename, "_pb")
     filename = join([filename, "jl"], '.')
     jfile.name = joinpath(outdir, filename)
     jfile.content = takebuf_string(io)


### PR DESCRIPTION
The postfix will generate files as such:
    filename.proto ----> filename_pb.jl

This will make it easy to identify files generated by protoc so that they can be
easily added to a .gitignore file or something similar.
