### PR TITLE
Convert Number and String default values to the correct type defined in the proto file

### DIFF
--- a/src/codec.jl
+++ b/src/codec.jl
@@ -49,8 +49,8 @@ wiretypes{T}(::Type{Array{T,1}})            = wiretypes(T)
 
 wiretype(t::Type) = wiretypes(t)[1]
 
-defaultval{T<:Number}(::Type{T})            = [0]
-defaultval{T<:String}(::Type{T})            = [""]
+defaultval{T<:Number}(::Type{T})            = [convert(T,0)]
+defaultval{T<:String}(::Type{T})            = [convert(T,"")]
 defaultval(::Type{Bool})                    = [false]
 defaultval{T}(::Type{Array{T,1}})           = [T[]]
 defaultval(::Type)                          = []


### PR DESCRIPTION
Assigning the default default values for optionals would results in a type mismatch.
