### PR TITLE
generate code for mutually-circular message defns

### DIFF
--- a/test/proto/recursive.proto
+++ b/test/proto/recursive.proto
@@ -1,0 +1,18 @@
+syntax = "proto2";
+
+package Recurse;
+
+message RecurseA {
+  required string a = 1;
+  optional RecurseB b = 2;
+}
+
+message RecurseB {
+    required string b = 1;
+    optional RecurseC c = 2;
+}
+
+message RecurseC {
+  required string c = 1;
+  optional RecurseB next = 2;
+}

--- a/test/testprotoc.sh
+++ b/test/testprotoc.sh
@@ -28,6 +28,8 @@ echo "- t1.proto" && ${GEN} ${SRC}/t1.proto && ${CHK} 'include("out/t1_pb.jl")'
 ERR=$(($ERR + $?))
 echo "- t2.proto" && ${GEN} ${SRC}/t2.proto && ${CHK} 'include("out/t2_pb.jl")'
 ERR=$(($ERR + $?))
+echo "- recursive.proto" && ${GEN} ${SRC}/recursive.proto && ${CHK} 'include("out/recursive_pb.jl")'
+ERR=$(($ERR + $?))
 echo "- a.proto, b.proto" && ${GEN} ${SRC}/a.proto ${SRC}/b.proto && ${CHK} 'include("out/AB.jl"); using AB; using AB.A, AB.B'
 ERR=$(($ERR + $?))
 echo "- module_type_name_collision.proto" && JULIA_PROTOBUF_MODULE_POSTFIX=1 ${GEN} ${SRC}/module_type_name_collision.proto && ${CHK} 'include("out/Foo_pb.jl"); using Foo_pb'


### PR DESCRIPTION
Julia does not allow mutually-circular type declarations yet (https://github.com/JuliaLang/julia/issues/269).
This change overcomes that by using `Any` to break cycles, while keeping the actual type information separately as metadata to be used while re-constructing objects from serialized data.