### PR TITLE
protobuf generated types extend abstract ProtoType

### DIFF
--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -7,7 +7,7 @@ import Base.show, Base.copy!
 export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta, protobuild
 export filled, isfilled, isfilled_default, which_oneof, fillset, fillset_default, fillunset
 export show, copy!, set_field, set_field!, get_field, clear, add_field, add_field!, has_field, isinitialized
-export ProtoEnum, lookup, enumstr
+export ProtoEnum, ProtoType, lookup, enumstr
 export ProtoServiceException, ProtoRpcChannel, ProtoRpcController, MethodDescriptor, ServiceDescriptor, ProtoService,
        AbstractProtoServiceStub, GenericProtoServiceStub, ProtoServiceStub, ProtoServiceBlockingStub,
        find_method, get_request_type, get_response_type, get_descriptor_for_type, call_method

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -697,6 +697,11 @@ function show(io::IO, m::ProtoMeta)
 end
 
 
+"""
+The abstract type from which all generated protobuf structs extend.
+"""
+abstract type ProtoType end
+
 ##
 # Enum Lookup
 

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -238,7 +238,7 @@ function generate(outio::IO, errio::IO, dtype::DescriptorProto, scope::Scope, sy
     end
 
     # generate this type
-    println(io, "mutable struct $(dtypename)")
+    println(io, "mutable struct $(dtypename) <: ProtoType")
     reqflds = String[]
     packedflds = String[]
     fldnums = Int[]

--- a/src/google/any_pb.jl
+++ b/src/google/any_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct _Any
+mutable struct _Any <: ProtoType
     type_url::AbstractString
     value::Array{UInt8,1}
     _Any(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)

--- a/src/google/api_pb.jl
+++ b/src/google/api_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct Method
+mutable struct Method <: ProtoType
     name::AbstractString
     request_type_url::AbstractString
     request_streaming::Bool
@@ -18,7 +18,7 @@ hash(v::Method) = ProtoBuf.protohash(v)
 isequal(v1::Method, v2::Method) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::Method, v2::Method) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct Mixin
+mutable struct Mixin <: ProtoType
     name::AbstractString
     root::AbstractString
     Mixin(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -27,7 +27,7 @@ hash(v::Mixin) = ProtoBuf.protohash(v)
 isequal(v1::Mixin, v2::Mixin) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::Mixin, v2::Mixin) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct Api
+mutable struct Api <: ProtoType
     name::AbstractString
     methods::Array{Method,1}
     options::Array{Option,1}

--- a/src/google/descriptor_pb.jl
+++ b/src/google/descriptor_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct UninterpretedOption_NamePart
+mutable struct UninterpretedOption_NamePart <: ProtoType
     name_part::AbstractString
     is_extension::Bool
     UninterpretedOption_NamePart(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -15,7 +15,7 @@ hash(v::UninterpretedOption_NamePart) = ProtoBuf.protohash(v)
 isequal(v1::UninterpretedOption_NamePart, v2::UninterpretedOption_NamePart) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::UninterpretedOption_NamePart, v2::UninterpretedOption_NamePart) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct UninterpretedOption
+mutable struct UninterpretedOption <: ProtoType
     name::Array{UninterpretedOption_NamePart,1}
     identifier_value::AbstractString
     positive_int_value::UInt64
@@ -47,7 +47,7 @@ struct __enum_FieldOptions_JSType <: ProtoEnum
 end #type __enum_FieldOptions_JSType
 const FieldOptions_JSType = __enum_FieldOptions_JSType()
 
-mutable struct FieldOptions
+mutable struct FieldOptions <: ProtoType
     ctype::Int32
     packed::Bool
     jstype::Int32
@@ -64,7 +64,7 @@ hash(v::FieldOptions) = ProtoBuf.protohash(v)
 isequal(v1::FieldOptions, v2::FieldOptions) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::FieldOptions, v2::FieldOptions) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct MessageOptions
+mutable struct MessageOptions <: ProtoType
     message_set_wire_format::Bool
     no_standard_descriptor_accessor::Bool
     deprecated::Bool
@@ -79,7 +79,7 @@ hash(v::MessageOptions) = ProtoBuf.protohash(v)
 isequal(v1::MessageOptions, v2::MessageOptions) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::MessageOptions, v2::MessageOptions) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct EnumOptions
+mutable struct EnumOptions <: ProtoType
     allow_alias::Bool
     deprecated::Bool
     uninterpreted_option::Array{UninterpretedOption,1}
@@ -92,7 +92,7 @@ hash(v::EnumOptions) = ProtoBuf.protohash(v)
 isequal(v1::EnumOptions, v2::EnumOptions) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::EnumOptions, v2::EnumOptions) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct MethodOptions
+mutable struct MethodOptions <: ProtoType
     deprecated::Bool
     uninterpreted_option::Array{UninterpretedOption,1}
     MethodOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -112,7 +112,7 @@ struct __enum_FileOptions_OptimizeMode <: ProtoEnum
 end #type __enum_FileOptions_OptimizeMode
 const FileOptions_OptimizeMode = __enum_FileOptions_OptimizeMode()
 
-mutable struct FileOptions
+mutable struct FileOptions <: ProtoType
     java_package::AbstractString
     java_outer_classname::AbstractString
     java_multiple_files::Bool
@@ -137,7 +137,7 @@ hash(v::FileOptions) = ProtoBuf.protohash(v)
 isequal(v1::FileOptions, v2::FileOptions) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::FileOptions, v2::FileOptions) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct EnumValueOptions
+mutable struct EnumValueOptions <: ProtoType
     deprecated::Bool
     uninterpreted_option::Array{UninterpretedOption,1}
     EnumValueOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -149,7 +149,7 @@ hash(v::EnumValueOptions) = ProtoBuf.protohash(v)
 isequal(v1::EnumValueOptions, v2::EnumValueOptions) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::EnumValueOptions, v2::EnumValueOptions) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct OneofOptions
+mutable struct OneofOptions <: ProtoType
     uninterpreted_option::Array{UninterpretedOption,1}
     OneofOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type OneofOptions
@@ -159,7 +159,7 @@ hash(v::OneofOptions) = ProtoBuf.protohash(v)
 isequal(v1::OneofOptions, v2::OneofOptions) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::OneofOptions, v2::OneofOptions) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct ServiceOptions
+mutable struct ServiceOptions <: ProtoType
     deprecated::Bool
     uninterpreted_option::Array{UninterpretedOption,1}
     ServiceOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -202,7 +202,7 @@ struct __enum_FieldDescriptorProto_Label <: ProtoEnum
 end #type __enum_FieldDescriptorProto_Label
 const FieldDescriptorProto_Label = __enum_FieldDescriptorProto_Label()
 
-mutable struct FieldDescriptorProto
+mutable struct FieldDescriptorProto <: ProtoType
     name::AbstractString
     number::Int32
     label::Int32
@@ -221,7 +221,7 @@ hash(v::FieldDescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::FieldDescriptorProto, v2::FieldDescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::FieldDescriptorProto, v2::FieldDescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct MethodDescriptorProto
+mutable struct MethodDescriptorProto <: ProtoType
     name::AbstractString
     input_type::AbstractString
     output_type::AbstractString
@@ -236,7 +236,7 @@ hash(v::MethodDescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::MethodDescriptorProto, v2::MethodDescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::MethodDescriptorProto, v2::MethodDescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct EnumValueDescriptorProto
+mutable struct EnumValueDescriptorProto <: ProtoType
     name::AbstractString
     number::Int32
     options::EnumValueOptions
@@ -246,7 +246,7 @@ hash(v::EnumValueDescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::EnumValueDescriptorProto, v2::EnumValueDescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::EnumValueDescriptorProto, v2::EnumValueDescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct EnumDescriptorProto
+mutable struct EnumDescriptorProto <: ProtoType
     name::AbstractString
     value::Array{EnumValueDescriptorProto,1}
     options::EnumOptions
@@ -256,7 +256,7 @@ hash(v::EnumDescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::EnumDescriptorProto, v2::EnumDescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::EnumDescriptorProto, v2::EnumDescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct OneofDescriptorProto
+mutable struct OneofDescriptorProto <: ProtoType
     name::AbstractString
     options::OneofOptions
     OneofDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -265,7 +265,7 @@ hash(v::OneofDescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::OneofDescriptorProto, v2::OneofDescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::OneofDescriptorProto, v2::OneofDescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct DescriptorProto_ExtensionRange
+mutable struct DescriptorProto_ExtensionRange <: ProtoType
     start::Int32
     _end::Int32
     DescriptorProto_ExtensionRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -274,7 +274,7 @@ hash(v::DescriptorProto_ExtensionRange) = ProtoBuf.protohash(v)
 isequal(v1::DescriptorProto_ExtensionRange, v2::DescriptorProto_ExtensionRange) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::DescriptorProto_ExtensionRange, v2::DescriptorProto_ExtensionRange) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct DescriptorProto_ReservedRange
+mutable struct DescriptorProto_ReservedRange <: ProtoType
     start::Int32
     _end::Int32
     DescriptorProto_ReservedRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -283,7 +283,7 @@ hash(v::DescriptorProto_ReservedRange) = ProtoBuf.protohash(v)
 isequal(v1::DescriptorProto_ReservedRange, v2::DescriptorProto_ReservedRange) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::DescriptorProto_ReservedRange, v2::DescriptorProto_ReservedRange) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct DescriptorProto
+mutable struct DescriptorProto <: ProtoType
     name::AbstractString
     field::Array{FieldDescriptorProto,1}
     extension::Array{FieldDescriptorProto,1}
@@ -302,7 +302,7 @@ hash(v::DescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::DescriptorProto, v2::DescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::DescriptorProto, v2::DescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct ServiceDescriptorProto
+mutable struct ServiceDescriptorProto <: ProtoType
     name::AbstractString
     method::Array{MethodDescriptorProto,1}
     options::ServiceOptions
@@ -312,7 +312,7 @@ hash(v::ServiceDescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::ServiceDescriptorProto, v2::ServiceDescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::ServiceDescriptorProto, v2::ServiceDescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct SourceCodeInfo_Location
+mutable struct SourceCodeInfo_Location <: ProtoType
     path::Array{Int32,1}
     span::Array{Int32,1}
     leading_comments::AbstractString
@@ -327,7 +327,7 @@ hash(v::SourceCodeInfo_Location) = ProtoBuf.protohash(v)
 isequal(v1::SourceCodeInfo_Location, v2::SourceCodeInfo_Location) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::SourceCodeInfo_Location, v2::SourceCodeInfo_Location) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct SourceCodeInfo
+mutable struct SourceCodeInfo <: ProtoType
     location::Array{SourceCodeInfo_Location,1}
     SourceCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type SourceCodeInfo
@@ -335,7 +335,7 @@ hash(v::SourceCodeInfo) = ProtoBuf.protohash(v)
 isequal(v1::SourceCodeInfo, v2::SourceCodeInfo) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::SourceCodeInfo, v2::SourceCodeInfo) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct FileDescriptorProto
+mutable struct FileDescriptorProto <: ProtoType
     name::AbstractString
     package::AbstractString
     dependency::Array{AbstractString,1}
@@ -356,7 +356,7 @@ hash(v::FileDescriptorProto) = ProtoBuf.protohash(v)
 isequal(v1::FileDescriptorProto, v2::FileDescriptorProto) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::FileDescriptorProto, v2::FileDescriptorProto) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct FileDescriptorSet
+mutable struct FileDescriptorSet <: ProtoType
     file::Array{FileDescriptorProto,1}
     FileDescriptorSet(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type FileDescriptorSet
@@ -364,7 +364,7 @@ hash(v::FileDescriptorSet) = ProtoBuf.protohash(v)
 isequal(v1::FileDescriptorSet, v2::FileDescriptorSet) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::FileDescriptorSet, v2::FileDescriptorSet) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct GeneratedCodeInfo_Annotation
+mutable struct GeneratedCodeInfo_Annotation <: ProtoType
     path::Array{Int32,1}
     source_file::AbstractString
     _begin::Int32
@@ -377,7 +377,7 @@ hash(v::GeneratedCodeInfo_Annotation) = ProtoBuf.protohash(v)
 isequal(v1::GeneratedCodeInfo_Annotation, v2::GeneratedCodeInfo_Annotation) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::GeneratedCodeInfo_Annotation, v2::GeneratedCodeInfo_Annotation) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct GeneratedCodeInfo
+mutable struct GeneratedCodeInfo <: ProtoType
     annotation::Array{GeneratedCodeInfo_Annotation,1}
     GeneratedCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type GeneratedCodeInfo

--- a/src/google/duration_pb.jl
+++ b/src/google/duration_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct Duration
+mutable struct Duration <: ProtoType
     seconds::Int64
     nanos::Int32
     Duration(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)

--- a/src/google/empty_pb.jl
+++ b/src/google/empty_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct Empty
+mutable struct Empty <: ProtoType
     Empty(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type Empty
 hash(v::Empty) = ProtoBuf.protohash(v)

--- a/src/google/field_mask_pb.jl
+++ b/src/google/field_mask_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct FieldMask
+mutable struct FieldMask <: ProtoType
     paths::Array{AbstractString,1}
     FieldMask(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type FieldMask

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -5,7 +5,7 @@ import ProtoBuf.meta
 import Base: hash, isequal, ==
 using ProtoBuf.GoogleProtoBuf
 
-mutable struct CodeGeneratorRequest
+mutable struct CodeGeneratorRequest <: ProtoType
     file_to_generate::Array{AbstractString,1}
     parameter::AbstractString
     proto_file::Array{FileDescriptorProto,1}
@@ -17,7 +17,7 @@ hash(v::CodeGeneratorRequest) = ProtoBuf.protohash(v)
 isequal(v1::CodeGeneratorRequest, v2::CodeGeneratorRequest) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::CodeGeneratorRequest, v2::CodeGeneratorRequest) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct CodeGeneratorResponse_File
+mutable struct CodeGeneratorResponse_File <: ProtoType
     name::AbstractString
     insertion_point::AbstractString
     content::AbstractString
@@ -29,7 +29,7 @@ hash(v::CodeGeneratorResponse_File) = ProtoBuf.protohash(v)
 isequal(v1::CodeGeneratorResponse_File, v2::CodeGeneratorResponse_File) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::CodeGeneratorResponse_File, v2::CodeGeneratorResponse_File) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct CodeGeneratorResponse
+mutable struct CodeGeneratorResponse <: ProtoType
     error::AbstractString
     file::Array{CodeGeneratorResponse_File,1}
     CodeGeneratorResponse(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)

--- a/src/google/source_context_pb.jl
+++ b/src/google/source_context_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct SourceContext
+mutable struct SourceContext <: ProtoType
     file_name::AbstractString
     SourceContext(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type SourceContext

--- a/src/google/struct_pb.jl
+++ b/src/google/struct_pb.jl
@@ -10,7 +10,7 @@ struct __enum_NullValue <: ProtoEnum
 end #type __enum_NullValue
 const NullValue = __enum_NullValue()
 
-mutable struct Struct
+mutable struct Struct <: ProtoType
     fields::Dict{AbstractString,Any} # map entry
     Struct(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type Struct
@@ -18,7 +18,7 @@ hash(v::Struct) = ProtoBuf.protohash(v)
 isequal(v1::Struct, v2::Struct) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::Struct, v2::Struct) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct ListValue
+mutable struct ListValue <: ProtoType
     values::Array{Any,1}
     ListValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type ListValue
@@ -26,7 +26,7 @@ hash(v::ListValue) = ProtoBuf.protohash(v)
 isequal(v1::ListValue, v2::ListValue) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::ListValue, v2::ListValue) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct Value
+mutable struct Value <: ProtoType
     null_value::Int32
     number_value::Float64
     string_value::AbstractString

--- a/src/google/timestamp_pb.jl
+++ b/src/google/timestamp_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct Timestamp
+mutable struct Timestamp <: ProtoType
     seconds::Int64
     nanos::Int32
     Timestamp(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)

--- a/src/google/type_pb.jl
+++ b/src/google/type_pb.jl
@@ -11,7 +11,7 @@ struct __enum_Syntax <: ProtoEnum
 end #type __enum_Syntax
 const Syntax = __enum_Syntax()
 
-mutable struct Option
+mutable struct Option <: ProtoType
     name::AbstractString
     value::_Any
     Option(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
@@ -20,7 +20,7 @@ hash(v::Option) = ProtoBuf.protohash(v)
 isequal(v1::Option, v2::Option) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::Option, v2::Option) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct EnumValue
+mutable struct EnumValue <: ProtoType
     name::AbstractString
     number::Int32
     options::Array{Option,1}
@@ -63,7 +63,7 @@ struct __enum_Field_Cardinality <: ProtoEnum
 end #type __enum_Field_Cardinality
 const Field_Cardinality = __enum_Field_Cardinality()
 
-mutable struct Field
+mutable struct Field <: ProtoType
     kind::Int32
     cardinality::Int32
     number::Int32
@@ -82,7 +82,7 @@ hash(v::Field) = ProtoBuf.protohash(v)
 isequal(v1::Field, v2::Field) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::Field, v2::Field) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct _Enum
+mutable struct _Enum <: ProtoType
     name::AbstractString
     enumvalue::Array{EnumValue,1}
     options::Array{Option,1}
@@ -94,7 +94,7 @@ hash(v::_Enum) = ProtoBuf.protohash(v)
 isequal(v1::_Enum, v2::_Enum) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::_Enum, v2::_Enum) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct _Type
+mutable struct _Type <: ProtoType
     name::AbstractString
     fields::Array{Field,1}
     oneofs::Array{AbstractString,1}

--- a/src/google/wrappers_pb.jl
+++ b/src/google/wrappers_pb.jl
@@ -4,7 +4,7 @@ using ProtoBuf
 import ProtoBuf.meta
 import Base: hash, isequal, ==
 
-mutable struct DoubleValue
+mutable struct DoubleValue <: ProtoType
     value::Float64
     DoubleValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type DoubleValue
@@ -12,7 +12,7 @@ hash(v::DoubleValue) = ProtoBuf.protohash(v)
 isequal(v1::DoubleValue, v2::DoubleValue) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::DoubleValue, v2::DoubleValue) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct FloatValue
+mutable struct FloatValue <: ProtoType
     value::Float32
     FloatValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type FloatValue
@@ -20,7 +20,7 @@ hash(v::FloatValue) = ProtoBuf.protohash(v)
 isequal(v1::FloatValue, v2::FloatValue) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::FloatValue, v2::FloatValue) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct Int64Value
+mutable struct Int64Value <: ProtoType
     value::Int64
     Int64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type Int64Value
@@ -28,7 +28,7 @@ hash(v::Int64Value) = ProtoBuf.protohash(v)
 isequal(v1::Int64Value, v2::Int64Value) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::Int64Value, v2::Int64Value) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct UInt64Value
+mutable struct UInt64Value <: ProtoType
     value::UInt64
     UInt64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type UInt64Value
@@ -36,7 +36,7 @@ hash(v::UInt64Value) = ProtoBuf.protohash(v)
 isequal(v1::UInt64Value, v2::UInt64Value) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::UInt64Value, v2::UInt64Value) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct Int32Value
+mutable struct Int32Value <: ProtoType
     value::Int32
     Int32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type Int32Value
@@ -44,7 +44,7 @@ hash(v::Int32Value) = ProtoBuf.protohash(v)
 isequal(v1::Int32Value, v2::Int32Value) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::Int32Value, v2::Int32Value) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct UInt32Value
+mutable struct UInt32Value <: ProtoType
     value::UInt32
     UInt32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type UInt32Value
@@ -52,7 +52,7 @@ hash(v::UInt32Value) = ProtoBuf.protohash(v)
 isequal(v1::UInt32Value, v2::UInt32Value) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::UInt32Value, v2::UInt32Value) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct BoolValue
+mutable struct BoolValue <: ProtoType
     value::Bool
     BoolValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type BoolValue
@@ -60,7 +60,7 @@ hash(v::BoolValue) = ProtoBuf.protohash(v)
 isequal(v1::BoolValue, v2::BoolValue) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::BoolValue, v2::BoolValue) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct StringValue
+mutable struct StringValue <: ProtoType
     value::AbstractString
     StringValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type StringValue
@@ -68,7 +68,7 @@ hash(v::StringValue) = ProtoBuf.protohash(v)
 isequal(v1::StringValue, v2::StringValue) = ProtoBuf.protoisequal(v1, v2)
 ==(v1::StringValue, v2::StringValue) = ProtoBuf.protoeq(v1, v2)
 
-mutable struct BytesValue
+mutable struct BytesValue <: ProtoType
     value::Array{UInt8,1}
     BytesValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #type BytesValue

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,7 @@ clear = fillunset
 
 has_field(obj::Any, fld::Symbol) = isfilled(obj, fld)
 
-function copy!(to::T, from::T) where T
+function copy!(to::T, from::T) where T <: ProtoType
     fillunset(to)
     fill = filled(from)
     fnames = fld_names(T)

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -14,28 +14,28 @@ end
 
 print_hdr(tname) = println("testing $tname...")
 
-mutable struct TestType
+mutable struct TestType <: ProtoType
     val::Any
 end
 
-mutable struct TestStr
+mutable struct TestStr <: ProtoType
     val::AbstractString
 end
 ==(t1::TestStr, t2::TestStr) = (t1.val == t2.val)
 
-mutable struct TestOptional
+mutable struct TestOptional <: ProtoType
     sVal1::TestStr
     sVal2::TestStr
     iVal2::Array{Int64,1}
 end
 
-mutable struct TestNested
+mutable struct TestNested <: ProtoType
     fld1::TestType
     fld2::TestOptional
     fld3::Array{TestStr}
 end
 
-mutable struct TestDefaults
+mutable struct TestDefaults <: ProtoType
     iVal1::Int64
     sVal2::AbstractString
     iVal2::Array{Int64,1}
@@ -44,7 +44,7 @@ mutable struct TestDefaults
     TestDefaults() = new()
 end
 
-mutable struct TestOneofs
+mutable struct TestOneofs <: ProtoType
     iVal1::Int64
     iVal2::Int64
     iVal3::Int64
@@ -52,14 +52,14 @@ mutable struct TestOneofs
     TestOneofs() = new()
 end
 
-mutable struct TestMaps
+mutable struct TestMaps <: ProtoType
     d1::Dict{Int,Int}
     d2::Dict{Int32,String}
     d3::Dict{String,String}
     TestMaps() = new()
 end
 
-mutable struct TestFilled
+mutable struct TestFilled <: ProtoType
     fld1::TestType
     fld2::TestType
     TestFilled() = new()


### PR DESCRIPTION
to avoid clashing `copy!` methods (and other such generic names) with other packages