### PR TITLE
using fully qualified names

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -531,7 +531,6 @@ function generate(io::IO, errio::IO, protofile::FileDescriptorProto)
         parentscope = (isdefined(scope, :parent) && scope.parent.is_module) ? fullname(scope.parent) : ""
         for dependency in using_pkgs
             (fullscopename == dependency) && continue
-            !isempty(parentscope) && startswith(dependency, parentscope) && (dependency = ".$(dependency[length(parentscope)+1:end])")
             if dependency == GOOGLE_PROTO3_EXTENSIONS
                 dependency = "ProtoBuf"
             else


### PR DESCRIPTION
In the generated code, use fully qualified names for field types instead of short name.

The motivation was stated in https://github.com/JuliaIO/ProtoBuf.jl/issues/97

I have been using a patched version for a few months, tested extended in a few ProtoBuf heavy projects (mostly as GRPC message types in a micro-service environment).

Within the pull request are a few changes,

1. `short_type_name` is renamed to `field_type_name` to better reflect its purpose as well as the new implementation
2. Instead of finding the shortest name it instead generate the fully qualified name. That is it returns `full_type_name` in most cases by `ProtoBuf.$full_type_name` when it is Google protobuf type.
3. In generated code, instead of `using $dependency`, now only `import $dependency`. And relies on the above full type name to resolve the type.
4. When type is `Any`, `Vector`, `Dict`, `Base.` is prepended.

This allows the package to work correctly with protobuf files that define types such as `Date`, `Vector` etc., without conflicts at runtime.