### PR TITLE
 regenerate wellknown protos (with new compiler)

### DIFF
--- a/gen/google/protobuf/any.proto
+++ b/gen/google/protobuf/any.proto
@@ -37,7 +37,6 @@ option go_package = "github.com/golang/protobuf/ptypes/any";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "AnyProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
 
 // `Any` contains an arbitrary serialized protocol buffer message along with a
@@ -75,6 +74,16 @@ option objc_class_prefix = "GPB";
 //       any.Unpack(foo)
 //       ...
 //
+//  Example 4: Pack and unpack a message in Go
+//
+//      foo := &pb.Foo{...}
+//      any, err := ptypes.MarshalAny(foo)
+//      ...
+//      foo := &pb.Foo{}
+//      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+//        ...
+//      }
+//
 // The pack methods provided by protobuf library will by default use
 // 'type.googleapis.com/full.type.name' as the type URL and the unpack
 // methods only use the fully qualified type name after the last '/'
@@ -111,17 +120,18 @@ option objc_class_prefix = "GPB";
 //     }
 //
 message Any {
-  // A URL/resource name whose content describes the type of the
-  // serialized protocol buffer message.
+  // A URL/resource name that uniquely identifies the type of the serialized
+  // protocol buffer message. The last segment of the URL's path must represent
+  // the fully qualified name of the type (as in
+  // `path/google.protobuf.Duration`). The name should be in a canonical form
+  // (e.g., leading "." is not accepted).
   //
-  // For URLs which use the scheme `http`, `https`, or no scheme, the
-  // following restrictions and interpretations apply:
+  // In practice, teams usually precompile into the binary all types that they
+  // expect it to use in the context of Any. However, for URLs which use the
+  // scheme `http`, `https`, or no scheme, one can optionally set up a type
+  // server that maps type URLs to message definitions as follows:
   //
   // * If no scheme is provided, `https` is assumed.
-  // * The last segment of the URL's path must represent the fully
-  //   qualified name of the type (as in `path/google.protobuf.Duration`).
-  //   The name should be in a canonical form (e.g., leading "." is
-  //   not accepted).
   // * An HTTP GET on the URL must yield a [google.protobuf.Type][]
   //   value in binary format, or produce an error.
   // * Applications are allowed to cache lookup results based on the
@@ -129,6 +139,10 @@ message Any {
   //   lookup. Therefore, binary compatibility needs to be preserved
   //   on changes to types. (Use versioned type names to manage
   //   breaking changes.)
+  //
+  // Note: this functionality is not currently available in the official
+  // protobuf release, and it is not used for type URLs beginning with
+  // type.googleapis.com.
   //
   // Schemes other than `http`, `https` (or the empty scheme) might be
   // used with implementation specific semantics.

--- a/gen/google/protobuf/api.proto
+++ b/gen/google/protobuf/api.proto
@@ -39,29 +39,36 @@ option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "ApiProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
+option go_package = "google.golang.org/genproto/protobuf/api;api";
 
-// Api is a light-weight descriptor for a protocol buffer service.
+// Api is a light-weight descriptor for an API Interface.
+//
+// Interfaces are also described as "protocol buffer services" in some contexts,
+// such as by the "service" keyword in a .proto file, but they are different
+// from API Services, which represent a concrete implementation of an interface
+// as opposed to simply a description of methods and bindings. They are also
+// sometimes simply referred to as "APIs" in other contexts, such as the name of
+// this message itself. See https://cloud.google.com/apis/design/glossary for
+// detailed terminology.
 message Api {
 
-  // The fully qualified name of this api, including package name
-  // followed by the api's simple name.
+  // The fully qualified name of this interface, including package name
+  // followed by the interface's simple name.
   string name = 1;
 
-  // The methods of this api, in unspecified order.
+  // The methods of this interface, in unspecified order.
   repeated Method methods = 2;
 
-  // Any metadata attached to the API.
+  // Any metadata attached to the interface.
   repeated Option options = 3;
 
-  // A version string for this api. If specified, must have the form
-  // `major-version.minor-version`, as in `1.10`. If the minor version
-  // is omitted, it defaults to zero. If the entire version field is
-  // empty, the major version is derived from the package name, as
-  // outlined below. If the field is not empty, the version in the
-  // package name will be verified to be consistent with what is
-  // provided here.
+  // A version string for this interface. If specified, must have the form
+  // `major-version.minor-version`, as in `1.10`. If the minor version is
+  // omitted, it defaults to zero. If the entire version field is empty, the
+  // major version is derived from the package name, as outlined below. If the
+  // field is not empty, the version in the package name will be verified to be
+  // consistent with what is provided here.
   //
   // The versioning schema uses [semantic
   // versioning](http://semver.org) where the major version number
@@ -71,10 +78,10 @@ message Api {
   // chosen based on the product plan.
   //
   // The major version is also reflected in the package name of the
-  // API, which must end in `v<major-version>`, as in
+  // interface, which must end in `v<major-version>`, as in
   // `google.feature.v1`. For major versions 0 and 1, the suffix can
   // be omitted. Zero major versions must only be used for
-  // experimental, none-GA apis.
+  // experimental, non-GA interfaces.
   //
   //
   string version = 4;
@@ -83,14 +90,14 @@ message Api {
   // message.
   SourceContext source_context = 5;
 
-  // Included APIs. See [Mixin][].
+  // Included interfaces. See [Mixin][].
   repeated Mixin mixins = 6;
 
   // The source syntax of the service.
   Syntax syntax = 7;
 }
 
-// Method represents a method of an api.
+// Method represents a method of an API interface.
 message Method {
 
   // The simple name of this method.
@@ -115,9 +122,9 @@ message Method {
   Syntax syntax = 7;
 }
 
-// Declares an API to be included in this API. The including API must
-// redeclare all the methods from the included API, but documentation
-// and options are inherited as follows:
+// Declares an API Interface to be included in this interface. The including
+// interface must redeclare all the methods from the included interface, but
+// documentation and options are inherited as follows:
 //
 // - If after comment and whitespace stripping, the documentation
 //   string of the redeclared method is empty, it will be inherited
@@ -129,7 +136,8 @@ message Method {
 //
 // - If an http annotation is inherited, the path pattern will be
 //   modified as follows. Any version prefix will be replaced by the
-//   version of the including API plus the [root][] path if specified.
+//   version of the including interface plus the [root][] path if
+//   specified.
 //
 // Example of a simple mixin:
 //
@@ -193,7 +201,7 @@ message Method {
 //       ...
 //     }
 message Mixin {
-  // The fully qualified name of the API which is included.
+  // The fully qualified name of the interface which is included.
   string name = 1;
 
   // If non-empty specifies a path under which inherited HTTP paths

--- a/gen/google/protobuf/compiler/plugin.proto
+++ b/gen/google/protobuf/compiler/plugin.proto
@@ -49,9 +49,19 @@ package google.protobuf.compiler;
 option java_package = "com.google.protobuf.compiler";
 option java_outer_classname = "PluginProtos";
 
-option go_package = "plugin_go";
+option go_package = "github.com/golang/protobuf/protoc-gen-go/plugin;plugin_go";
 
 import "google/protobuf/descriptor.proto";
+
+// The version number of protocol compiler.
+message Version {
+  optional int32 major = 1;
+  optional int32 minor = 2;
+  optional int32 patch = 3;
+  // A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+  // be empty for mainline stable releases.
+  optional string suffix = 4;
+}
 
 // An encoded CodeGeneratorRequest is written to the plugin's stdin.
 message CodeGeneratorRequest {
@@ -74,7 +84,14 @@ message CodeGeneratorRequest {
   // the entire set into memory at once.  However, as of this writing, this
   // is not similarly optimized on protoc's end -- it will store all fields in
   // memory at once before sending them to the plugin.
+  //
+  // Type names of fields and extensions in the FileDescriptorProto are always
+  // fully qualified.
   repeated FileDescriptorProto proto_file = 15;
+
+  // The version number of protocol compiler.
+  optional Version compiler_version = 3;
+
 }
 
 // The plugin writes an encoded CodeGeneratorResponse to stdout.

--- a/gen/google/protobuf/descriptor.proto
+++ b/gen/google/protobuf/descriptor.proto
@@ -40,12 +40,12 @@
 syntax = "proto2";
 
 package google.protobuf;
-option go_package = "descriptor";
+option go_package = "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "DescriptorProtos";
 option csharp_namespace = "Google.Protobuf.Reflection";
 option objc_class_prefix = "GPB";
-option java_generate_equals_and_hash = true;
+option cc_enable_arenas = true;
 
 // descriptor.proto must be optimized for speed because reflection-based
 // algorithms don't work during bootstrapping.
@@ -102,6 +102,8 @@ message DescriptorProto {
   message ExtensionRange {
     optional int32 start = 1;
     optional int32 end = 2;
+
+    optional ExtensionRangeOptions options = 3;
   }
   repeated ExtensionRange extension_range = 5;
 
@@ -122,6 +124,14 @@ message DescriptorProto {
   repeated string reserved_name = 10;
 }
 
+message ExtensionRangeOptions {
+  // The parser stores options it doesn't recognize here. See above.
+  repeated UninterpretedOption uninterpreted_option = 999;
+
+  // Clients can define custom options in extensions of this message. See above.
+  extensions 1000 to max;
+}
+
 // Describes a field within a message.
 message FieldDescriptorProto {
   enum Type {
@@ -140,7 +150,11 @@ message FieldDescriptorProto {
     TYPE_FIXED32        = 7;
     TYPE_BOOL           = 8;
     TYPE_STRING         = 9;
-    TYPE_GROUP          = 10;  // Tag-delimited aggregate.
+    // Tag-delimited aggregate.
+    // Group type is deprecated and not supported in proto3. However, Proto3
+    // implementations should still be able to parse the group wire format and
+    // treat group fields as unknown fields.
+    TYPE_GROUP          = 10;
     TYPE_MESSAGE        = 11;  // Length-delimited aggregate.
 
     // New in version 2.
@@ -158,7 +172,6 @@ message FieldDescriptorProto {
     LABEL_OPTIONAL      = 1;
     LABEL_REQUIRED      = 2;
     LABEL_REPEATED      = 3;
-    // TODO(sanjay): Should we add LABEL_MAP?
   };
 
   optional string name = 1;
@@ -213,6 +226,26 @@ message EnumDescriptorProto {
   repeated EnumValueDescriptorProto value = 2;
 
   optional EnumOptions options = 3;
+
+  // Range of reserved numeric values. Reserved values may not be used by
+  // entries in the same enum. Reserved ranges may not overlap.
+  //
+  // Note that this is distinct from DescriptorProto.ReservedRange in that it
+  // is inclusive such that it can appropriately represent the entire int32
+  // domain.
+  message EnumReservedRange {
+    optional int32 start = 1; // Inclusive.
+    optional int32 end = 2;   // Inclusive.
+  }
+
+  // Range of reserved numeric values. Reserved numeric values may not be used
+  // by enum values in the same enum declaration. Reserved ranges may not
+  // overlap.
+  repeated EnumReservedRange reserved_range = 4;
+
+  // Reserved enum value names, which may not be reused. A given name may only
+  // be reserved once.
+  repeated string reserved_name = 5;
 }
 
 // Describes a value within an enum.
@@ -306,19 +339,8 @@ message FileOptions {
   // top-level extensions defined in the file.
   optional bool java_multiple_files = 10 [default=false];
 
-  // If set true, then the Java code generator will generate equals() and
-  // hashCode() methods for all messages defined in the .proto file.
-  // This increases generated code size, potentially substantially for large
-  // protos, which may harm a memory-constrained application.
-  // - In the full runtime this is a speed optimization, as the
-  // AbstractMessage base class includes reflection-based implementations of
-  // these methods.
-  // - In the lite runtime, setting this option changes the semantics of
-  // equals() and hashCode() to more closely match those of the full runtime;
-  // the generated methods compute their results based on field values rather
-  // than object identity. (Implementations should not assume that hashcodes
-  // will be consistent across runtimes or versions of the protocol compiler.)
-  optional bool java_generate_equals_and_hash = 20 [default=false];
+  // This option does nothing.
+  optional bool java_generate_equals_and_hash = 20 [deprecated=true];
 
   // If set true, then the Java2 code generator will generate code that
   // throws an exception whenever an attempt is made to assign a non-UTF-8
@@ -360,6 +382,7 @@ message FileOptions {
   optional bool cc_generic_services = 16 [default=false];
   optional bool java_generic_services = 17 [default=false];
   optional bool py_generic_services = 18 [default=false];
+  optional bool php_generic_services = 42 [default=false];
 
   // Is this file deprecated?
   // Depending on the target platform, this can emit Deprecated annotations
@@ -379,10 +402,38 @@ message FileOptions {
   // Namespace for generated classes; defaults to the package.
   optional string csharp_namespace = 37;
 
-  // The parser stores options it doesn't recognize here. See above.
+  // By default Swift generators will take the proto package and CamelCase it
+  // replacing '.' with underscore and use that to prefix the types/symbols
+  // defined. When this options is provided, they will use this value instead
+  // to prefix the types/symbols defined.
+  optional string swift_prefix = 39;
+
+  // Sets the php class prefix which is prepended to all php generated classes
+  // from this .proto. Default is empty.
+  optional string php_class_prefix = 40;
+
+  // Use this option to change the namespace of php generated classes. Default
+  // is empty. When this option is empty, the package name will be used for
+  // determining the namespace.
+  optional string php_namespace = 41;
+
+
+  // Use this option to change the namespace of php generated metadata classes.
+  // Default is empty. When this option is empty, the proto file name will be used
+  // for determining the namespace.
+  optional string php_metadata_namespace = 44;
+
+  // Use this option to change the package of ruby generated classes. Default
+  // is empty. When this option is not set, the package name will be used for
+  // determining the ruby package.
+  optional string ruby_package = 45;
+
+  // The parser stores options it doesn't recognize here.
+  // See the documentation for the "Options" section above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
-  // Clients can define custom options in extensions of this message. See above.
+  // Clients can define custom options in extensions of this message.
+  // See the documentation for the "Options" section above.
   extensions 1000 to max;
 
   reserved 38;
@@ -443,6 +494,9 @@ message MessageOptions {
   // parser.
   optional bool map_entry = 7;
 
+  reserved 8;  // javalite_serializable
+  reserved 9;  // javanano_as_lite
+
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
 
@@ -471,16 +525,17 @@ message FieldOptions {
   // false will avoid using packed encoding.
   optional bool packed = 2;
 
-
   // The jstype option determines the JavaScript type used for values of the
   // field.  The option is permitted only for 64 bit integral and fixed types
-  // (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
-  // represented as JavaScript strings.  This avoids loss of precision that can
-  // happen when a large value is converted to a floating point JavaScript
-  // numbers.  Specifying JS_NUMBER for the jstype causes the generated
-  // JavaScript code to use the JavaScript "number" type instead of strings.
-  // This option is an enum to permit additional types to be added,
-  // e.g. goog.math.Integer.
+  // (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+  // is represented as JavaScript string, which avoids loss of precision that
+  // can happen when a large value is converted to a floating point JavaScript.
+  // Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+  // use the JavaScript "number" type.  The behavior of the default option
+  // JS_NORMAL is implementation dependent.
+  //
+  // This option is an enum to permit additional types to be added, e.g.
+  // goog.math.Integer.
   optional JSType jstype = 6 [default = JS_NORMAL];
   enum JSType {
     // Use the default type.
@@ -512,7 +567,7 @@ message FieldOptions {
   //
   //
   // Note that implementations may choose not to check required fields within
-  // a lazy sub-message.  That is, calling IsInitialized() on the outher message
+  // a lazy sub-message.  That is, calling IsInitialized() on the outer message
   // may return true even if the inner message has missing required fields.
   // This is necessary because otherwise the inner message would have to be
   // parsed in order to perform the check, defeating the purpose of lazy
@@ -538,6 +593,8 @@ message FieldOptions {
 
   // Clients can define custom options in extensions of this message. See above.
   extensions 1000 to max;
+
+  reserved 4;  // removed jtype
 }
 
 message OneofOptions {
@@ -559,6 +616,8 @@ message EnumOptions {
   // for the enum, or it will be completely ignored; in the very least, this
   // is a formalization for deprecating enums.
   optional bool deprecated = 3 [default=false];
+
+  reserved 5;  // javanano_as_lite
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;
@@ -613,6 +672,17 @@ message MethodOptions {
   // for the method, or it will be completely ignored; in the very least,
   // this is a formalization for deprecating methods.
   optional bool deprecated = 33 [default=false];
+
+  // Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+  // or neither? HTTP based RPC implementation may choose GET verb for safe
+  // methods, and PUT verb for idempotent methods instead of the default POST.
+  enum IdempotencyLevel {
+    IDEMPOTENCY_UNKNOWN = 0;
+    NO_SIDE_EFFECTS     = 1; // implies idempotent
+    IDEMPOTENT          = 2; // idempotent, but may have side effects
+  }
+  optional IdempotencyLevel idempotency_level =
+      34 [default=IDEMPOTENCY_UNKNOWN];
 
   // The parser stores options it doesn't recognize here. See above.
   repeated UninterpretedOption uninterpreted_option = 999;

--- a/gen/google/protobuf/duration.proto
+++ b/gen/google/protobuf/duration.proto
@@ -33,11 +33,11 @@ syntax = "proto3";
 package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
 option go_package = "github.com/golang/protobuf/ptypes/duration";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "DurationProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
 
 // A Duration represents a signed, fixed-length span of time represented
@@ -46,6 +46,8 @@ option objc_class_prefix = "GPB";
 // or "month". It is related to Timestamp in that the difference between
 // two Timestamp values is a Duration and it can be added or subtracted
 // from a Timestamp. Range is approximately +-10,000 years.
+//
+// # Examples
 //
 // Example 1: Compute Duration from two Timestamps in pseudo code.
 //
@@ -81,11 +83,28 @@ option objc_class_prefix = "GPB";
 //       end.nanos -= 1000000000;
 //     }
 //
+// Example 3: Compute Duration from datetime.timedelta in Python.
+//
+//     td = datetime.timedelta(days=3, minutes=10)
+//     duration = Duration()
+//     duration.FromTimedelta(td)
+//
+// # JSON Mapping
+//
+// In JSON format, the Duration type is encoded as a string rather than an
+// object, where the string ends in the suffix "s" (indicating seconds) and
+// is preceded by the number of seconds, with nanoseconds expressed as
+// fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+// microsecond should be expressed in JSON format as "3.000001s".
+//
 //
 message Duration {
 
   // Signed seconds of the span of time. Must be from -315,576,000,000
-  // to +315,576,000,000 inclusive.
+  // to +315,576,000,000 inclusive. Note: these bounds are computed from:
+  // 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
   int64 seconds = 1;
 
   // Signed fractions of a second at nanosecond resolution of the span

--- a/gen/google/protobuf/empty.proto
+++ b/gen/google/protobuf/empty.proto
@@ -37,7 +37,6 @@ option go_package = "github.com/golang/protobuf/ptypes/empty";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "EmptyProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
 option cc_enable_arenas = true;
 

--- a/gen/google/protobuf/field_mask.proto
+++ b/gen/google/protobuf/field_mask.proto
@@ -37,7 +37,7 @@ option java_package = "com.google.protobuf";
 option java_outer_classname = "FieldMaskProto";
 option java_multiple_files = true;
 option objc_class_prefix = "GPB";
-option java_generate_equals_and_hash = true;
+option go_package = "google.golang.org/genproto/protobuf/field_mask;field_mask";
 
 // `FieldMask` represents a set of symbolic field paths, for example:
 //
@@ -82,7 +82,7 @@ option java_generate_equals_and_hash = true;
 //     }
 //
 // A repeated field is not allowed except at the last position of a
-// field mask.
+// paths string.
 //
 // If a FieldMask object is not present in a get operation, the
 // operation applies to all fields (as if a FieldMask of all fields
@@ -109,8 +109,8 @@ option java_generate_equals_and_hash = true;
 //
 // If a repeated field is specified for an update operation, the existing
 // repeated values in the target resource will be overwritten by the new values.
-// Note that a repeated field is only allowed in the last position of a field
-// mask.
+// Note that a repeated field is only allowed in the last position of a `paths`
+// string.
 //
 // If a sub-message is specified in the last position of the field mask for an
 // update operation, then the existing sub-message in the target resource is
@@ -240,6 +240,12 @@ option java_generate_equals_and_hash = true;
 //
 // Note that oneof type names ("test_oneof" in this case) cannot be used in
 // paths.
+//
+// ## Field Mask Verification
+//
+// The implementation of any API method which has a FieldMask type field in the
+// request should verify the included field paths, and return an
+// `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
 message FieldMask {
   // The set of field mask paths.
   repeated string paths = 1;

--- a/gen/google/protobuf/source_context.proto
+++ b/gen/google/protobuf/source_context.proto
@@ -36,8 +36,8 @@ option csharp_namespace = "Google.Protobuf.WellKnownTypes";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "SourceContextProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
+option go_package = "google.golang.org/genproto/protobuf/source_context;source_context";
 
 // `SourceContext` represents information about the source of a
 // protobuf element, like the file in which it is defined.

--- a/gen/google/protobuf/struct.proto
+++ b/gen/google/protobuf/struct.proto
@@ -33,18 +33,13 @@ syntax = "proto3";
 package google.protobuf;
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
 option go_package = "github.com/golang/protobuf/ptypes/struct;structpb";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "StructProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
 
-// `AnyValue` is an alias for `Value`.
-// This is a custom modification for Julia code to work around the
-// circular reference problem between `Struct`, `ListValue` and `Value`.
-// `AnyValue` must be replaced with the Julia `Any` type.
-message AnyValue {}
 
 // `Struct` represents a structured data value, consisting of fields
 // which map to dynamically typed values. In some languages, `Struct`
@@ -56,9 +51,7 @@ message AnyValue {}
 // The JSON representation for `Struct` is JSON object.
 message Struct {
   // Unordered map of dynamically typed values.
-  // The value type was originally `Value`. It has been replaced 
-  // with `AnyValue` for Julia code generation as described above.
-  map<string, AnyValue> fields = 1;
+  map<string, Value> fields = 1;
 }
 
 // `Value` represents a dynamically typed value which can be either
@@ -99,7 +92,5 @@ enum NullValue {
 // The JSON representation for `ListValue` is JSON array.
 message ListValue {
   // Repeated field of dynamically typed values.
-  // The element type was originally `Value`. It has been replaced 
-  // with `AnyValue` for Julia code generation as described above.
-  repeated AnyValue values = 1;
+  repeated Value values = 1;
 }

--- a/gen/google/protobuf/timestamp.proto
+++ b/gen/google/protobuf/timestamp.proto
@@ -38,7 +38,6 @@ option go_package = "github.com/golang/protobuf/ptypes/timestamp";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "TimestampProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
 
 // A Timestamp represents a point in time independent of any time zone
@@ -52,6 +51,8 @@ option objc_class_prefix = "GPB";
 // By restricting to that range, we ensure that we can convert to
 // and from  RFC 3339 date strings.
 // See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+//
+// # Examples
 //
 // Example 1: Compute Timestamp from POSIX `time()`.
 //
@@ -90,16 +91,39 @@ option objc_class_prefix = "GPB";
 //
 // Example 5: Compute Timestamp from current time in Python.
 //
-//     now = time.time()
-//     seconds = int(now)
-//     nanos = int((now - seconds) * 10**9)
-//     timestamp = Timestamp(seconds=seconds, nanos=nanos)
+//     timestamp = Timestamp()
+//     timestamp.GetCurrentTime()
+//
+// # JSON Mapping
+//
+// In JSON format, the Timestamp type is encoded as a string in the
+// [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+// format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+// where {year} is always expressed using four digits while {month}, {day},
+// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+// is required. A proto3 JSON serializer should always use UTC (as indicated by
+// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+// able to accept both UTC and other timezones (as indicated by an offset).
+//
+// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+// 01:30 UTC on January 15, 2017.
+//
+// In JavaScript, one can convert a Date object to this format using the
+// standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
+// method. In Python, a standard `datetime.datetime` object can be converted
+// to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+// with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+// can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
+// http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
+// ) to obtain a formatter capable of generating timestamps in this format.
 //
 //
 message Timestamp {
 
   // Represents seconds of UTC time since Unix epoch
-  // 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
+  // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
   // 9999-12-31T23:59:59Z inclusive.
   int64 seconds = 1;
 

--- a/gen/google/protobuf/type.proto
+++ b/gen/google/protobuf/type.proto
@@ -36,11 +36,12 @@ import "google/protobuf/any.proto";
 import "google/protobuf/source_context.proto";
 
 option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
 option java_package = "com.google.protobuf";
 option java_outer_classname = "TypeProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
+option go_package = "google.golang.org/genproto/protobuf/ptype;ptype";
 
 // A protocol buffer message type.
 message Type {
@@ -165,9 +166,15 @@ message EnumValue {
 // A protocol buffer option, which can be attached to a message, field,
 // enumeration, etc.
 message Option {
-  // The option's name. For example, `"java_package"`.
+  // The option's name. For protobuf built-in options (options defined in
+  // descriptor.proto), this is the short name. For example, `"map_entry"`.
+  // For custom options, it should be the fully-qualified name. For example,
+  // `"google.api.http"`.
   string name = 1;
-  // The option's value. For example, `"com.google.protobuf"`.
+  // The option's value packed in an Any message. If the value is a primitive,
+  // the corresponding wrapper type defined in google/protobuf/wrappers.proto
+  // should be used. If the value is an enum, it should be stored as an int32
+  // value using the google.protobuf.Int32Value type.
   Any value = 2;
 }
 

--- a/gen/google/protobuf/wrappers.proto
+++ b/gen/google/protobuf/wrappers.proto
@@ -43,7 +43,6 @@ option go_package = "github.com/golang/protobuf/ptypes/wrappers";
 option java_package = "com.google.protobuf";
 option java_outer_classname = "WrappersProto";
 option java_multiple_files = true;
-option java_generate_equals_and_hash = true;
 option objc_class_prefix = "GPB";
 
 // Wrapper message for `double`.

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -10,6 +10,11 @@ const WIRETYP_GRPSTART = 3   # deprecated
 const WIRETYP_GRPEND   = 4   # deprecated
 const WIRETYP_32BIT    = 5
 
+"""
+The abstract type from which all generated protobuf structs extend.
+"""
+abstract type ProtoType end
+
 # TODO: wiretypes should become julia types, so that methods can be parameterized on them
 const WIRETYPES = Dict{Symbol,Tuple}(
     :int32          => (WIRETYP_VARINT,     :write_varint,  :read_varint,   Int32),
@@ -388,6 +393,7 @@ function read_lendelim_obj(io, val, meta::ProtoMeta, reader)
 end
 
 instantiate(t::Type) = ccall(:jl_new_struct_uninit, Any, (Any,), t)
+instantiate(t::T) where {T <: ProtoType} = T()
 
 function skip_field(io::IO, wiretype::Integer)
     if wiretype == WIRETYP_LENDELIM
@@ -695,11 +701,6 @@ function show(io::IO, m::ProtoMeta)
     println(io, m.ordered)
 end
 
-
-"""
-The abstract type from which all generated protobuf structs extend.
-"""
-abstract type ProtoType end
 
 ##
 # Enum Lookup

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -365,7 +365,7 @@ function writeproto(io::IO, obj, meta::ProtoMeta=meta(typeof(obj)))
             @logmsg("writeproto writing field: $fld")
             n += writeproto(io, getfield(obj, fld), attrib)
         else
-            @logmsg("firld not set: $fld")
+            @logmsg("field not set: $fld")
             (attrib.occurrence == 1) && error("missing required field $fld (#$(attrib.fldnum))")
         end
     end

--- a/src/google/any_pb.jl
+++ b/src/google/any_pb.jl
@@ -7,6 +7,6 @@ mutable struct _Any <: ProtoType
     type_url::AbstractString
     value::Array{UInt8,1}
     _Any(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type _Any
+end #mutable struct _Any
 
 export _Any

--- a/src/google/api_pb.jl
+++ b/src/google/api_pb.jl
@@ -9,26 +9,26 @@ mutable struct Method <: ProtoType
     request_streaming::Bool
     response_type_url::AbstractString
     response_streaming::Bool
-    options::Array{Option,1}
+    options::Base.Vector{Option}
     syntax::Int32
     Method(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Method
+end #mutable struct Method
 
 mutable struct Mixin <: ProtoType
     name::AbstractString
     root::AbstractString
     Mixin(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Mixin
+end #mutable struct Mixin
 
 mutable struct Api <: ProtoType
     name::AbstractString
-    methods::Array{Method,1}
-    options::Array{Option,1}
+    methods::Base.Vector{Method}
+    options::Base.Vector{Option}
     version::AbstractString
     source_context::SourceContext
-    mixins::Array{Mixin,1}
+    mixins::Base.Vector{Mixin}
     syntax::Int32
     Api(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Api
+end #mutable struct Api
 
 export Api, Method, Mixin

--- a/src/google/descriptor_pb.jl
+++ b/src/google/descriptor_pb.jl
@@ -7,12 +7,12 @@ mutable struct UninterpretedOption_NamePart <: ProtoType
     name_part::AbstractString
     is_extension::Bool
     UninterpretedOption_NamePart(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type UninterpretedOption_NamePart
+end #mutable struct UninterpretedOption_NamePart
 const __req_UninterpretedOption_NamePart = Symbol[:name_part,:is_extension]
-meta(t::Type{UninterpretedOption_NamePart}) = meta(t, __req_UninterpretedOption_NamePart, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{UninterpretedOption_NamePart}) = meta(t, __req_UninterpretedOption_NamePart, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct UninterpretedOption <: ProtoType
-    name::Array{UninterpretedOption_NamePart,1}
+    name::Base.Vector{UninterpretedOption_NamePart}
     identifier_value::AbstractString
     positive_int_value::UInt64
     negative_int_value::Int64
@@ -20,16 +20,16 @@ mutable struct UninterpretedOption <: ProtoType
     string_value::Array{UInt8,1}
     aggregate_value::AbstractString
     UninterpretedOption(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type UninterpretedOption
+end #mutable struct UninterpretedOption
 const __fnum_UninterpretedOption = Int[2,3,4,5,6,7,8]
-meta(t::Type{UninterpretedOption}) = meta(t, ProtoBuf.DEF_REQ, __fnum_UninterpretedOption, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{UninterpretedOption}) = meta(t, ProtoBuf.DEF_REQ, __fnum_UninterpretedOption, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 struct __enum_FieldOptions_CType <: ProtoEnum
     STRING::Int32
     CORD::Int32
     STRING_PIECE::Int32
     __enum_FieldOptions_CType() = new(0,1,2)
-end #type __enum_FieldOptions_CType
+end #struct __enum_FieldOptions_CType
 const FieldOptions_CType = __enum_FieldOptions_CType()
 
 struct __enum_FieldOptions_JSType <: ProtoEnum
@@ -37,7 +37,7 @@ struct __enum_FieldOptions_JSType <: ProtoEnum
     JS_STRING::Int32
     JS_NUMBER::Int32
     __enum_FieldOptions_JSType() = new(0,1,2)
-end #type __enum_FieldOptions_JSType
+end #struct __enum_FieldOptions_JSType
 const FieldOptions_JSType = __enum_FieldOptions_JSType()
 
 mutable struct FieldOptions <: ProtoType
@@ -47,50 +47,66 @@ mutable struct FieldOptions <: ProtoType
     lazy::Bool
     deprecated::Bool
     weak::Bool
-    uninterpreted_option::Array{UninterpretedOption,1}
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     FieldOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type FieldOptions
+end #mutable struct FieldOptions
 const __val_FieldOptions = Dict(:ctype => FieldOptions_CType.STRING, :jstype => FieldOptions_JSType.JS_NORMAL, :lazy => false, :deprecated => false, :weak => false)
 const __fnum_FieldOptions = Int[1,2,6,5,3,10,999]
-meta(t::Type{FieldOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FieldOptions, __val_FieldOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{FieldOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FieldOptions, __val_FieldOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct MessageOptions <: ProtoType
     message_set_wire_format::Bool
     no_standard_descriptor_accessor::Bool
     deprecated::Bool
     map_entry::Bool
-    uninterpreted_option::Array{UninterpretedOption,1}
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     MessageOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type MessageOptions
+end #mutable struct MessageOptions
 const __val_MessageOptions = Dict(:message_set_wire_format => false, :no_standard_descriptor_accessor => false, :deprecated => false)
 const __fnum_MessageOptions = Int[1,2,3,7,999]
-meta(t::Type{MessageOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_MessageOptions, __val_MessageOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{MessageOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_MessageOptions, __val_MessageOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct EnumOptions <: ProtoType
     allow_alias::Bool
     deprecated::Bool
-    uninterpreted_option::Array{UninterpretedOption,1}
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     EnumOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type EnumOptions
+end #mutable struct EnumOptions
 const __val_EnumOptions = Dict(:deprecated => false)
 const __fnum_EnumOptions = Int[2,3,999]
-meta(t::Type{EnumOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_EnumOptions, __val_EnumOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{EnumOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_EnumOptions, __val_EnumOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct ExtensionRangeOptions <: ProtoType
+    uninterpreted_option::Base.Vector{UninterpretedOption}
+    ExtensionRangeOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ExtensionRangeOptions
+const __fnum_ExtensionRangeOptions = Int[999]
+meta(t::Type{ExtensionRangeOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_ExtensionRangeOptions, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+struct __enum_MethodOptions_IdempotencyLevel <: ProtoEnum
+    IDEMPOTENCY_UNKNOWN::Int32
+    NO_SIDE_EFFECTS::Int32
+    IDEMPOTENT::Int32
+    __enum_MethodOptions_IdempotencyLevel() = new(0,1,2)
+end #struct __enum_MethodOptions_IdempotencyLevel
+const MethodOptions_IdempotencyLevel = __enum_MethodOptions_IdempotencyLevel()
 
 mutable struct MethodOptions <: ProtoType
     deprecated::Bool
-    uninterpreted_option::Array{UninterpretedOption,1}
+    idempotency_level::Int32
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     MethodOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type MethodOptions
-const __val_MethodOptions = Dict(:deprecated => false)
-const __fnum_MethodOptions = Int[33,999]
-meta(t::Type{MethodOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_MethodOptions, __val_MethodOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end #mutable struct MethodOptions
+const __val_MethodOptions = Dict(:deprecated => false, :idempotency_level => MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN)
+const __fnum_MethodOptions = Int[33,34,999]
+meta(t::Type{MethodOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_MethodOptions, __val_MethodOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 struct __enum_FileOptions_OptimizeMode <: ProtoEnum
     SPEED::Int32
     CODE_SIZE::Int32
     LITE_RUNTIME::Int32
     __enum_FileOptions_OptimizeMode() = new(1,2,3)
-end #type __enum_FileOptions_OptimizeMode
+end #struct __enum_FileOptions_OptimizeMode
 const FileOptions_OptimizeMode = __enum_FileOptions_OptimizeMode()
 
 mutable struct FileOptions <: ProtoType
@@ -104,41 +120,47 @@ mutable struct FileOptions <: ProtoType
     cc_generic_services::Bool
     java_generic_services::Bool
     py_generic_services::Bool
+    php_generic_services::Bool
     deprecated::Bool
     cc_enable_arenas::Bool
     objc_class_prefix::AbstractString
     csharp_namespace::AbstractString
-    uninterpreted_option::Array{UninterpretedOption,1}
+    swift_prefix::AbstractString
+    php_class_prefix::AbstractString
+    php_namespace::AbstractString
+    php_metadata_namespace::AbstractString
+    ruby_package::AbstractString
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     FileOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type FileOptions
-const __val_FileOptions = Dict(:java_multiple_files => false, :java_generate_equals_and_hash => false, :java_string_check_utf8 => false, :optimize_for => FileOptions_OptimizeMode.SPEED, :cc_generic_services => false, :java_generic_services => false, :py_generic_services => false, :deprecated => false, :cc_enable_arenas => false)
-const __fnum_FileOptions = Int[1,8,10,20,27,9,11,16,17,18,23,31,36,37,999]
-meta(t::Type{FileOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FileOptions, __val_FileOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end #mutable struct FileOptions
+const __val_FileOptions = Dict(:java_multiple_files => false, :java_string_check_utf8 => false, :optimize_for => FileOptions_OptimizeMode.SPEED, :cc_generic_services => false, :java_generic_services => false, :py_generic_services => false, :php_generic_services => false, :deprecated => false, :cc_enable_arenas => false)
+const __fnum_FileOptions = Int[1,8,10,20,27,9,11,16,17,18,42,23,31,36,37,39,40,41,44,45,999]
+meta(t::Type{FileOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FileOptions, __val_FileOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct EnumValueOptions <: ProtoType
     deprecated::Bool
-    uninterpreted_option::Array{UninterpretedOption,1}
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     EnumValueOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type EnumValueOptions
+end #mutable struct EnumValueOptions
 const __val_EnumValueOptions = Dict(:deprecated => false)
 const __fnum_EnumValueOptions = Int[1,999]
-meta(t::Type{EnumValueOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_EnumValueOptions, __val_EnumValueOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{EnumValueOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_EnumValueOptions, __val_EnumValueOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct OneofOptions <: ProtoType
-    uninterpreted_option::Array{UninterpretedOption,1}
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     OneofOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type OneofOptions
+end #mutable struct OneofOptions
 const __fnum_OneofOptions = Int[999]
-meta(t::Type{OneofOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_OneofOptions, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{OneofOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_OneofOptions, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct ServiceOptions <: ProtoType
     deprecated::Bool
-    uninterpreted_option::Array{UninterpretedOption,1}
+    uninterpreted_option::Base.Vector{UninterpretedOption}
     ServiceOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type ServiceOptions
+end #mutable struct ServiceOptions
 const __val_ServiceOptions = Dict(:deprecated => false)
 const __fnum_ServiceOptions = Int[33,999]
-meta(t::Type{ServiceOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_ServiceOptions, __val_ServiceOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{ServiceOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_ServiceOptions, __val_ServiceOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 struct __enum_FieldDescriptorProto_Type <: ProtoEnum
     TYPE_DOUBLE::Int32
@@ -160,7 +182,7 @@ struct __enum_FieldDescriptorProto_Type <: ProtoEnum
     TYPE_SINT32::Int32
     TYPE_SINT64::Int32
     __enum_FieldDescriptorProto_Type() = new(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18)
-end #type __enum_FieldDescriptorProto_Type
+end #struct __enum_FieldDescriptorProto_Type
 const FieldDescriptorProto_Type = __enum_FieldDescriptorProto_Type()
 
 struct __enum_FieldDescriptorProto_Label <: ProtoEnum
@@ -168,7 +190,7 @@ struct __enum_FieldDescriptorProto_Label <: ProtoEnum
     LABEL_REQUIRED::Int32
     LABEL_REPEATED::Int32
     __enum_FieldDescriptorProto_Label() = new(1,2,3)
-end #type __enum_FieldDescriptorProto_Label
+end #struct __enum_FieldDescriptorProto_Label
 const FieldDescriptorProto_Label = __enum_FieldDescriptorProto_Label()
 
 mutable struct FieldDescriptorProto <: ProtoType
@@ -183,9 +205,16 @@ mutable struct FieldDescriptorProto <: ProtoType
     json_name::AbstractString
     options::FieldOptions
     FieldDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type FieldDescriptorProto
+end #mutable struct FieldDescriptorProto
 const __fnum_FieldDescriptorProto = Int[1,3,4,5,6,2,7,9,10,8]
-meta(t::Type{FieldDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FieldDescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{FieldDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FieldDescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+
+mutable struct DescriptorProto_ExtensionRange <: ProtoType
+    start::Int32
+    _end::Int32
+    options::ExtensionRangeOptions
+    DescriptorProto_ExtensionRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct DescriptorProto_ExtensionRange
 
 mutable struct MethodDescriptorProto <: ProtoType
     name::AbstractString
@@ -195,118 +224,120 @@ mutable struct MethodDescriptorProto <: ProtoType
     client_streaming::Bool
     server_streaming::Bool
     MethodDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type MethodDescriptorProto
+end #mutable struct MethodDescriptorProto
 const __val_MethodDescriptorProto = Dict(:client_streaming => false, :server_streaming => false)
-meta(t::Type{MethodDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_MethodDescriptorProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{MethodDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_MethodDescriptorProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct EnumValueDescriptorProto <: ProtoType
     name::AbstractString
     number::Int32
     options::EnumValueOptions
     EnumValueDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type EnumValueDescriptorProto
+end #mutable struct EnumValueDescriptorProto
+
+mutable struct EnumDescriptorProto_EnumReservedRange <: ProtoType
+    start::Int32
+    _end::Int32
+    EnumDescriptorProto_EnumReservedRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct EnumDescriptorProto_EnumReservedRange
 
 mutable struct EnumDescriptorProto <: ProtoType
     name::AbstractString
-    value::Array{EnumValueDescriptorProto,1}
+    value::Base.Vector{EnumValueDescriptorProto}
     options::EnumOptions
+    reserved_range::Base.Vector{EnumDescriptorProto_EnumReservedRange}
+    reserved_name::Base.Vector{AbstractString}
     EnumDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type EnumDescriptorProto
+end #mutable struct EnumDescriptorProto
 
 mutable struct OneofDescriptorProto <: ProtoType
     name::AbstractString
     options::OneofOptions
     OneofDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type OneofDescriptorProto
-
-mutable struct DescriptorProto_ExtensionRange <: ProtoType
-    start::Int32
-    _end::Int32
-    DescriptorProto_ExtensionRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type DescriptorProto_ExtensionRange
+end #mutable struct OneofDescriptorProto
 
 mutable struct DescriptorProto_ReservedRange <: ProtoType
     start::Int32
     _end::Int32
     DescriptorProto_ReservedRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type DescriptorProto_ReservedRange
+end #mutable struct DescriptorProto_ReservedRange
 
 mutable struct DescriptorProto <: ProtoType
     name::AbstractString
-    field::Array{FieldDescriptorProto,1}
-    extension::Array{FieldDescriptorProto,1}
-    nested_type::Array{DescriptorProto,1}
-    enum_type::Array{EnumDescriptorProto,1}
-    extension_range::Array{DescriptorProto_ExtensionRange,1}
-    oneof_decl::Array{OneofDescriptorProto,1}
+    field::Base.Vector{FieldDescriptorProto}
+    extension::Base.Vector{FieldDescriptorProto}
+    nested_type::Base.Vector{DescriptorProto}
+    enum_type::Base.Vector{EnumDescriptorProto}
+    extension_range::Base.Vector{DescriptorProto_ExtensionRange}
+    oneof_decl::Base.Vector{OneofDescriptorProto}
     options::MessageOptions
-    reserved_range::Array{DescriptorProto_ReservedRange,1}
-    reserved_name::Array{AbstractString,1}
+    reserved_range::Base.Vector{DescriptorProto_ReservedRange}
+    reserved_name::Base.Vector{AbstractString}
     DescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type DescriptorProto
+end #mutable struct DescriptorProto
 const __fnum_DescriptorProto = Int[1,2,6,3,4,5,8,7,9,10]
-meta(t::Type{DescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_DescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{DescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_DescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct ServiceDescriptorProto <: ProtoType
     name::AbstractString
-    method::Array{MethodDescriptorProto,1}
+    method::Base.Vector{MethodDescriptorProto}
     options::ServiceOptions
     ServiceDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type ServiceDescriptorProto
+end #mutable struct ServiceDescriptorProto
 
 mutable struct SourceCodeInfo_Location <: ProtoType
-    path::Array{Int32,1}
-    span::Array{Int32,1}
+    path::Base.Vector{Int32}
+    span::Base.Vector{Int32}
     leading_comments::AbstractString
     trailing_comments::AbstractString
-    leading_detached_comments::Array{AbstractString,1}
+    leading_detached_comments::Base.Vector{AbstractString}
     SourceCodeInfo_Location(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type SourceCodeInfo_Location
+end #mutable struct SourceCodeInfo_Location
 const __fnum_SourceCodeInfo_Location = Int[1,2,3,4,6]
 const __pack_SourceCodeInfo_Location = Symbol[:path,:span]
-meta(t::Type{SourceCodeInfo_Location}) = meta(t, ProtoBuf.DEF_REQ, __fnum_SourceCodeInfo_Location, ProtoBuf.DEF_VAL, true, __pack_SourceCodeInfo_Location, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{SourceCodeInfo_Location}) = meta(t, ProtoBuf.DEF_REQ, __fnum_SourceCodeInfo_Location, ProtoBuf.DEF_VAL, true, __pack_SourceCodeInfo_Location, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct SourceCodeInfo <: ProtoType
-    location::Array{SourceCodeInfo_Location,1}
+    location::Base.Vector{SourceCodeInfo_Location}
     SourceCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type SourceCodeInfo
+end #mutable struct SourceCodeInfo
 
 mutable struct FileDescriptorProto <: ProtoType
     name::AbstractString
     package::AbstractString
-    dependency::Array{AbstractString,1}
-    public_dependency::Array{Int32,1}
-    weak_dependency::Array{Int32,1}
-    message_type::Array{DescriptorProto,1}
-    enum_type::Array{EnumDescriptorProto,1}
-    service::Array{ServiceDescriptorProto,1}
-    extension::Array{FieldDescriptorProto,1}
+    dependency::Base.Vector{AbstractString}
+    public_dependency::Base.Vector{Int32}
+    weak_dependency::Base.Vector{Int32}
+    message_type::Base.Vector{DescriptorProto}
+    enum_type::Base.Vector{EnumDescriptorProto}
+    service::Base.Vector{ServiceDescriptorProto}
+    extension::Base.Vector{FieldDescriptorProto}
     options::FileOptions
     source_code_info::SourceCodeInfo
     syntax::AbstractString
     FileDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type FileDescriptorProto
+end #mutable struct FileDescriptorProto
 const __fnum_FileDescriptorProto = Int[1,2,3,10,11,4,5,6,7,8,9,12]
-meta(t::Type{FileDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FileDescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{FileDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FileDescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct FileDescriptorSet <: ProtoType
-    file::Array{FileDescriptorProto,1}
+    file::Base.Vector{FileDescriptorProto}
     FileDescriptorSet(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type FileDescriptorSet
+end #mutable struct FileDescriptorSet
 
 mutable struct GeneratedCodeInfo_Annotation <: ProtoType
-    path::Array{Int32,1}
+    path::Base.Vector{Int32}
     source_file::AbstractString
     _begin::Int32
     _end::Int32
     GeneratedCodeInfo_Annotation(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type GeneratedCodeInfo_Annotation
+end #mutable struct GeneratedCodeInfo_Annotation
 const __pack_GeneratedCodeInfo_Annotation = Symbol[:path]
-meta(t::Type{GeneratedCodeInfo_Annotation}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, __pack_GeneratedCodeInfo_Annotation, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{GeneratedCodeInfo_Annotation}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, __pack_GeneratedCodeInfo_Annotation, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct GeneratedCodeInfo <: ProtoType
-    annotation::Array{GeneratedCodeInfo_Annotation,1}
+    annotation::Base.Vector{GeneratedCodeInfo_Annotation}
     GeneratedCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type GeneratedCodeInfo
+end #mutable struct GeneratedCodeInfo
 
-export FileDescriptorSet, FileDescriptorProto, DescriptorProto_ExtensionRange, DescriptorProto_ReservedRange, DescriptorProto, FieldDescriptorProto_Type, FieldDescriptorProto_Label, FieldDescriptorProto, OneofDescriptorProto, EnumDescriptorProto, EnumValueDescriptorProto, ServiceDescriptorProto, MethodDescriptorProto, FileOptions_OptimizeMode, FileOptions, MessageOptions, FieldOptions_CType, FieldOptions_JSType, FieldOptions, OneofOptions, EnumOptions, EnumValueOptions, ServiceOptions, MethodOptions, UninterpretedOption_NamePart, UninterpretedOption, SourceCodeInfo_Location, SourceCodeInfo, GeneratedCodeInfo_Annotation, GeneratedCodeInfo
+export FileDescriptorSet, FileDescriptorProto, DescriptorProto_ExtensionRange, DescriptorProto_ReservedRange, DescriptorProto, ExtensionRangeOptions, FieldDescriptorProto_Type, FieldDescriptorProto_Label, FieldDescriptorProto, OneofDescriptorProto, EnumDescriptorProto_EnumReservedRange, EnumDescriptorProto, EnumValueDescriptorProto, ServiceDescriptorProto, MethodDescriptorProto, FileOptions_OptimizeMode, FileOptions, MessageOptions, FieldOptions_CType, FieldOptions_JSType, FieldOptions, OneofOptions, EnumOptions, EnumValueOptions, ServiceOptions, MethodOptions_IdempotencyLevel, MethodOptions, UninterpretedOption_NamePart, UninterpretedOption, SourceCodeInfo_Location, SourceCodeInfo, GeneratedCodeInfo_Annotation, GeneratedCodeInfo

--- a/src/google/duration_pb.jl
+++ b/src/google/duration_pb.jl
@@ -7,6 +7,6 @@ mutable struct Duration <: ProtoType
     seconds::Int64
     nanos::Int32
     Duration(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Duration
+end #mutable struct Duration
 
 export Duration

--- a/src/google/empty_pb.jl
+++ b/src/google/empty_pb.jl
@@ -5,6 +5,6 @@ import ProtoBuf.meta
 
 mutable struct Empty <: ProtoType
     Empty(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Empty
+end #mutable struct Empty
 
 export Empty

--- a/src/google/field_mask_pb.jl
+++ b/src/google/field_mask_pb.jl
@@ -4,8 +4,8 @@ using ProtoBuf
 import ProtoBuf.meta
 
 mutable struct FieldMask <: ProtoType
-    paths::Array{AbstractString,1}
+    paths::Base.Vector{AbstractString}
     FieldMask(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type FieldMask
+end #mutable struct FieldMask
 
 export FieldMask

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -1,7 +1,6 @@
 # syntax: proto2
 using Compat
 using ProtoBuf
-using ProtoBuf.GoogleProtoBuf
 import ProtoBuf.meta
 
 mutable struct Version <: ProtoType

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -1,33 +1,42 @@
 # syntax: proto2
 using Compat
 using ProtoBuf
-import ProtoBuf.meta
 using ProtoBuf.GoogleProtoBuf
+import ProtoBuf.meta
+
+mutable struct Version <: ProtoType
+    major::Int32
+    minor::Int32
+    patch::Int32
+    suffix::AbstractString
+    Version(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct Version
 
 mutable struct CodeGeneratorRequest <: ProtoType
-    file_to_generate::Array{AbstractString,1}
+    file_to_generate::Base.Vector{AbstractString}
     parameter::AbstractString
-    proto_file::Array{FileDescriptorProto,1}
+    proto_file::Base.Vector{ProtoBuf.GoogleProtoBuf.FileDescriptorProto}
+    compiler_version::Version
     CodeGeneratorRequest(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type CodeGeneratorRequest
-const __fnum_CodeGeneratorRequest = Int[1,2,15]
-meta(t::Type{CodeGeneratorRequest}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorRequest, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end #mutable struct CodeGeneratorRequest
+const __fnum_CodeGeneratorRequest = Int[1,2,15,3]
+meta(t::Type{CodeGeneratorRequest}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorRequest, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct CodeGeneratorResponse_File <: ProtoType
     name::AbstractString
     insertion_point::AbstractString
     content::AbstractString
     CodeGeneratorResponse_File(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type CodeGeneratorResponse_File
+end #mutable struct CodeGeneratorResponse_File
 const __fnum_CodeGeneratorResponse_File = Int[1,2,15]
-meta(t::Type{CodeGeneratorResponse_File}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorResponse_File, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{CodeGeneratorResponse_File}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorResponse_File, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct CodeGeneratorResponse <: ProtoType
     error::AbstractString
-    file::Array{CodeGeneratorResponse_File,1}
+    file::Base.Vector{CodeGeneratorResponse_File}
     CodeGeneratorResponse(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type CodeGeneratorResponse
+end #mutable struct CodeGeneratorResponse
 const __fnum_CodeGeneratorResponse = Int[1,15]
-meta(t::Type{CodeGeneratorResponse}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorResponse, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{CodeGeneratorResponse}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorResponse, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
-export CodeGeneratorRequest, CodeGeneratorResponse_File, CodeGeneratorResponse
+export Version, CodeGeneratorRequest, CodeGeneratorResponse_File, CodeGeneratorResponse

--- a/src/google/source_context_pb.jl
+++ b/src/google/source_context_pb.jl
@@ -6,6 +6,6 @@ import ProtoBuf.meta
 mutable struct SourceContext <: ProtoType
     file_name::AbstractString
     SourceContext(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type SourceContext
+end #mutable struct SourceContext
 
 export SourceContext

--- a/src/google/struct_pb.jl
+++ b/src/google/struct_pb.jl
@@ -6,18 +6,23 @@ import ProtoBuf.meta
 struct __enum_NullValue <: ProtoEnum
     NULL_VALUE::Int32
     __enum_NullValue() = new(0)
-end #type __enum_NullValue
+end #struct __enum_NullValue
 const NullValue = __enum_NullValue()
 
-mutable struct Struct <: ProtoType
-    fields::Dict{AbstractString,Any} # map entry
-    Struct(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Struct
+mutable struct Struct_FieldsEntry <: ProtoType
+    key::AbstractString
+    value::Base.Any
+    Struct_FieldsEntry(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct Struct_FieldsEntry (mapentry) (has cyclic type dependency)
+const __ftype_Struct_FieldsEntry = Dict(:value => "Value")
+meta(t::Type{Struct_FieldsEntry}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, __ftype_Struct_FieldsEntry)
 
-mutable struct ListValue <: ProtoType
-    values::Array{Any,1}
-    ListValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type ListValue
+mutable struct Struct <: ProtoType
+    fields::Base.Dict # map entry
+    Struct(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct Struct (has cyclic type dependency)
+const __ftype_Struct = Dict(:fields => "Base.Dict{AbstractString,Value}")
+meta(t::Type{Struct}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, __ftype_Struct)
 
 mutable struct Value <: ProtoType
     null_value::Int32
@@ -25,25 +30,18 @@ mutable struct Value <: ProtoType
     string_value::AbstractString
     bool_value::Bool
     struct_value::Struct
-    list_value::ListValue
+    list_value::Base.Any
     Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Value
+end #mutable struct Value (has cyclic type dependency)
+const __ftype_Value = Dict(:list_value => "ListValue")
 const __oneofs_Value = Int[1,1,1,1,1,1]
 const __oneof_names_Value = [Symbol("kind")]
-meta(t::Type{Value}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, __oneofs_Value, __oneof_names_Value)
+meta(t::Type{Value}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, __oneofs_Value, __oneof_names_Value, __ftype_Value)
 
-function meta(t::Type{ListValue})
-    haskey(ProtoBuf._metacache, t) && (return ProtoBuf._metacache[t])
-    m = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
-    m.ordered[1].meta = meta(Value)
-    m
-end
+mutable struct ListValue <: ProtoType
+    values::Base.Vector{Value}
+    ListValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+end #mutable struct ListValue (has cyclic type dependency)
 
-function meta(t::Type{Struct})
-    haskey(ProtoBuf._metacache, t) && (return ProtoBuf._metacache[t])
-    m = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
-    m.ordered[1].meta = ProtoBuf.mapentry_meta(Dict{AbstractString,Value})
-    m
-end
-
-export NullValue, Struct, Value, ListValue
+export NullValue, Struct_FieldsEntry, Struct, Value, ListValue, Struct_FieldsEntry, Struct, Value, ListValue
+# mapentries: "Struct_FieldsEntry"=>("AbstractString", "Value")

--- a/src/google/timestamp_pb.jl
+++ b/src/google/timestamp_pb.jl
@@ -7,6 +7,6 @@ mutable struct Timestamp <: ProtoType
     seconds::Int64
     nanos::Int32
     Timestamp(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Timestamp
+end #mutable struct Timestamp
 
 export Timestamp

--- a/src/google/type_pb.jl
+++ b/src/google/type_pb.jl
@@ -7,21 +7,21 @@ struct __enum_Syntax <: ProtoEnum
     SYNTAX_PROTO2::Int32
     SYNTAX_PROTO3::Int32
     __enum_Syntax() = new(0,1)
-end #type __enum_Syntax
+end #struct __enum_Syntax
 const Syntax = __enum_Syntax()
 
 mutable struct Option <: ProtoType
     name::AbstractString
     value::_Any
     Option(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Option
+end #mutable struct Option
 
 mutable struct EnumValue <: ProtoType
     name::AbstractString
     number::Int32
-    options::Array{Option,1}
+    options::Base.Vector{Option}
     EnumValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type EnumValue
+end #mutable struct EnumValue
 
 struct __enum_Field_Kind <: ProtoEnum
     TYPE_UNKNOWN::Int32
@@ -44,7 +44,7 @@ struct __enum_Field_Kind <: ProtoEnum
     TYPE_SINT32::Int32
     TYPE_SINT64::Int32
     __enum_Field_Kind() = new(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18)
-end #type __enum_Field_Kind
+end #struct __enum_Field_Kind
 const Field_Kind = __enum_Field_Kind()
 
 struct __enum_Field_Cardinality <: ProtoEnum
@@ -53,7 +53,7 @@ struct __enum_Field_Cardinality <: ProtoEnum
     CARDINALITY_REQUIRED::Int32
     CARDINALITY_REPEATED::Int32
     __enum_Field_Cardinality() = new(0,1,2,3)
-end #type __enum_Field_Cardinality
+end #struct __enum_Field_Cardinality
 const Field_Cardinality = __enum_Field_Cardinality()
 
 mutable struct Field <: ProtoType
@@ -64,31 +64,31 @@ mutable struct Field <: ProtoType
     type_url::AbstractString
     oneof_index::Int32
     packed::Bool
-    options::Array{Option,1}
+    options::Base.Vector{Option}
     json_name::AbstractString
     default_value::AbstractString
     Field(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Field
+end #mutable struct Field
 const __fnum_Field = Int[1,2,3,4,6,7,8,9,10,11]
-meta(t::Type{Field}) = meta(t, ProtoBuf.DEF_REQ, __fnum_Field, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+meta(t::Type{Field}) = meta(t, ProtoBuf.DEF_REQ, __fnum_Field, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
 
 mutable struct _Enum <: ProtoType
     name::AbstractString
-    enumvalue::Array{EnumValue,1}
-    options::Array{Option,1}
+    enumvalue::Base.Vector{EnumValue}
+    options::Base.Vector{Option}
     source_context::SourceContext
     syntax::Int32
     _Enum(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type _Enum
+end #mutable struct _Enum
 
 mutable struct _Type <: ProtoType
     name::AbstractString
-    fields::Array{Field,1}
-    oneofs::Array{AbstractString,1}
-    options::Array{Option,1}
+    fields::Base.Vector{Field}
+    oneofs::Base.Vector{AbstractString}
+    options::Base.Vector{Option}
     source_context::SourceContext
     syntax::Int32
     _Type(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type _Type
+end #mutable struct _Type
 
 export Syntax, _Type, Field_Kind, Field_Cardinality, Field, _Enum, EnumValue, Option

--- a/src/google/wrappers_pb.jl
+++ b/src/google/wrappers_pb.jl
@@ -6,46 +6,46 @@ import ProtoBuf.meta
 mutable struct DoubleValue <: ProtoType
     value::Float64
     DoubleValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type DoubleValue
+end #mutable struct DoubleValue
 
 mutable struct FloatValue <: ProtoType
     value::Float32
     FloatValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type FloatValue
+end #mutable struct FloatValue
 
 mutable struct Int64Value <: ProtoType
     value::Int64
     Int64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Int64Value
+end #mutable struct Int64Value
 
 mutable struct UInt64Value <: ProtoType
     value::UInt64
     UInt64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type UInt64Value
+end #mutable struct UInt64Value
 
 mutable struct Int32Value <: ProtoType
     value::Int32
     Int32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type Int32Value
+end #mutable struct Int32Value
 
 mutable struct UInt32Value <: ProtoType
     value::UInt32
     UInt32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type UInt32Value
+end #mutable struct UInt32Value
 
 mutable struct BoolValue <: ProtoType
     value::Bool
     BoolValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type BoolValue
+end #mutable struct BoolValue
 
 mutable struct StringValue <: ProtoType
     value::AbstractString
     StringValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type StringValue
+end #mutable struct StringValue
 
 mutable struct BytesValue <: ProtoType
     value::Array{UInt8,1}
     BytesValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #type BytesValue
+end #mutable struct BytesValue
 
 export DoubleValue, FloatValue, Int64Value, UInt64Value, Int32Value, UInt32Value, BoolValue, StringValue, BytesValue


### PR DESCRIPTION
- use latest proto files for wellknown protos
- fix a codegen issue when a may type field has a defered type
- regenerate julia code with latest ProtoBuf.jl
    - now that it can handle cyclic type references, we do not need to manually update protos or generated code