### PR TITLE
use split from Compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6.0
-Compat 0.69.0
+Compat 0.70.0

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -149,7 +149,7 @@ function findmodule(name::String)
 end
 
 function field_type_name(full_type_name::String)
-    comps = @static (VERSION < v"0.7.0-DEV.4724") ? split(full_type_name, '.'; keep=false) : split(full_type_name, '.'; keepempty=false)
+    comps = Compat.split(full_type_name, '.'; keepempty=false)
     if isempty(comps)
         type_name = full_type_name
     else
@@ -617,7 +617,7 @@ function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
                 dependency = "ProtoBuf." * dependency
                 add_import(dependency)
             else
-                comps = @static (VERSION < v"0.7.0-DEV.4724") ? split(dependency, '.'; keep=false) : split(dependency, '.'; keepempty=false)
+                comps = Compat.split(dependency, '.'; keepempty=false)
                 if startswith(dependency, parentscope*".")
                     comps[1] = ".." * comps[1]
                 elseif !isempty(fullscopename)

--- a/test/setup_protoc3.sh
+++ b/test/setup_protoc3.sh
@@ -1,9 +1,26 @@
+#! /usr/bin/env bash
+
 PROTO3_ROOT=/proto3
 mkdir $PROTO3_ROOT
 
 PROTO3_VER=3.6.0
 PROTO3_PATH=$PROTO3_ROOT/protobuf-$PROTO3_VER
-PROTO3_SRC=https://github.com/google/protobuf/releases/download/v${PROTO3_VER}/protobuf-cpp-${PROTO3_VER}.tar.gz
 
-curl -s -L ${PROTO3_SRC} | tar -C ${PROTO3_ROOT} -x -z -f -
-cd ${PROTO3_PATH} && mkdir install && ./autogen.sh && ./configure --prefix=${PROTO3_PATH}/install && make install
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    PROTO3_BIN=https://github.com/google/protobuf/releases/download/v${PROTO3_VER}/protoc-${PROTO3_VER}-linux-x86_64.zip
+    curl -OL $PROTO3_BIN
+    mkdir -p ${PROTO3_PATH}/install/bin
+    unzip protoc-${PROTO3_VER}-linux-x86_64.zip -d ${PROTO3_PATH}/install
+    rm protoc-${PROTO3_VER}-linux-x86_64.zip
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    PROTO3_BIN=https://github.com/google/protobuf/releases/download/v${PROTO3_VER}/protoc-${PROTO3_VER}-osx-x86_64.zip
+    curl -OL $PROTO3_BIN
+    mkdir -p ${PROTO3_PATH}/install/bin
+    unzip protoc-${PROTO3_VER}-osx-x86_64.zip -d ${PROTO3_PATH}/install
+    rm protoc-${PROTO3_VER}-osx-x86_64.zip
+else
+    # compile from source
+    PROTO3_SRC=https://github.com/google/protobuf/releases/download/v${PROTO3_VER}/protobuf-cpp-${PROTO3_VER}.tar.gz
+    curl -s -L ${PROTO3_SRC} | tar -C ${PROTO3_ROOT} -x -z -f -
+    cd ${PROTO3_PATH} && mkdir install && ./autogen.sh && ./configure --prefix=${PROTO3_PATH}/install && make install
+fi


### PR DESCRIPTION
Minor updates:
- use `split` from Compat.jl
- update protoc3 install scripts to install binaries when possible, reducing setup time, and making CI (travis) faster