### PR TITLE
Improve ProtoBuf generation on 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ before_install:
   - sudo apt-get install protobuf-compiler
   - sudo apt-get install curl
   - sudo ./test/setup_protoc3.sh
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - PROTOC2=protoc PROTOC3=/proto3/protobuf-3.6.0/install/bin/protoc julia --check-bounds=yes -e '(VERSION > v"0.7.0-") && (using Pkg); Pkg.clone(pwd()); Pkg.build("ProtoBuf"); Pkg.test("ProtoBuf"; coverage=true)'
+  - export PROTOC2=protoc
+  - export PROTOC3=/proto3/protobuf-3.6.0/install/bin/protoc
 after_success:
   - julia -e 'cd(Pkg.dir("ProtoBuf")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder());'
   - julia -e 'cd(Pkg.dir("ProtoBuf")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/PROTOC.md
+++ b/PROTOC.md
@@ -18,6 +18,17 @@ If a package contains a message which has the same name as the package itself, o
 
 ProtoBuf `map` types are generated as Julia `Dict` types by default. They can also be generated as `Array` of `key-value`s by setting the `JULIA_PROTOBUF_MAP_AS_ARRAY=1` environment variable when running `protoc`.
 
+### From within Julia
+For convenience, ProtoBuf.jl exports a `protoc(args)` command that will setup the `PATH` correctly to make sure `protoc` can find the
+plugin as well as making sure that that the plugin can find the correct julia installation. To make use of this feature for the example
+above, simply run  (from a Julia REPL):
+
+```
+julia> using ProtoBuf
+
+julia> run(ProtoBuf.protoc(`-I=proto --julia_out=jlout proto/plugin.proto`))
+```
+
 ### Windows Specifics of Code Generation
 
 On Windows, the procedure of compiling the .jl from .proto files is similar:

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,8 @@
+name = "ProtoBuf"
+uuid = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
+keywords = ["protobuf", "protoc"]
+license = "MIT"
+desc = "Julia protobuf implementation"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/plugin/protoc-gen-julia
+++ b/plugin/protoc-gen-julia
@@ -15,9 +15,11 @@ if [ ${JULIA_PROTOBUF_MAP_AS_ARRAY:-0} -eq 1 ]; then
     FLAGS="${FLAGS} --map-as-array"
 fi
 
+export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+JULIA_GEN="${JULIA} ${COVERAGE} -e 'if VERSION >= v\"0.7-\"; import Pkg; Pkg.activate(joinpath(ENV[\"SCRIPT_DIR\"], \"..\")); end; using ProtoBuf; using ProtoBuf.Gen; gen()'"
 if [ -z ${FLAGS} ]
 then
-    ${JULIA} ${COVERAGE} -e 'using ProtoBuf; using ProtoBuf.Gen; gen()'
+    eval " ${JULIA_GEN}"
 else
-    ${JULIA} ${COVERAGE} -e 'using ProtoBuf; using ProtoBuf.Gen; gen()' -- ${FLAGS}
+    eval " ${JULIA_GEN} -- ${FLAGS}"
 fi

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,3 +99,10 @@ function enumstr(enumname, t::Int32)
     end
     error(string("Invalid enum value ", t, " for ", typeof(enumname)))
 end
+
+function protoc(args=``)
+    ENV′ = copy(ENV)
+    ENV′["PATH"] = string(joinpath(@__DIR__, "..", "plugin"), ":", ENV′["PATH"])
+    ENV′["JULIA"] = joinpath(Sys.BINDIR, Base.julia_exename())
+    setenv(`protoc $args`, ENV′)
+end

--- a/test/testprotoc.jl
+++ b/test/testprotoc.jl
@@ -6,8 +6,11 @@ else
     test_script = joinpath(@__DIR__, "testprotoc.sh")
     protogen_path = joinpath(@__DIR__, "..", "plugin")
     path_env = "$(protogen_path):$(ENV["PATH"])"
+    modified_env = Dict{String, String}()
     is_ci = "CI" in keys(ENV)
-    cov_flags = is_ci ? """ COVERAGE="--code-coverage=user --inline=no" """ : ""
+    if is_ci
+        modified_env["COVERAGE"] = "--code-coverage=user --inline=no"
+    end
     protoc_compilers = []
     for protoc_env in ("PROTOC2", "PROTOC3")
         if protoc_env in keys(ENV)
@@ -20,9 +23,11 @@ else
         println("testing protobuf compiler plugin...")
         is_ci && println("detected CI environment, will enable code coverage...")
         for protoc_compiler in protoc_compilers
-            cmd = `bash -c "PATH=$(path_env) PROTOC=$(protoc_compiler) $(cov_flags) $(test_script)"`
+            modified_env["PROTOC"] = protoc_compiler
+            modified_env["PATH"] = path_env
+            modified_env["JULIA"] = joinpath(Compat.Sys.BINDIR, Base.julia_exename())
             println("testing protoc compiler plugin with ", protoc_compiler)
-            run(cmd)
+            run(setenv(`$test_script`, modified_env))
         end
     end
 end

--- a/test/testprotoc.sh
+++ b/test/testprotoc.sh
@@ -13,7 +13,8 @@ fi
 PROTOC_VER=`${PROTOC} --version | cut -d" " -f2 | cut -d"." -f1`
 echo "compiler version $PROTOC_VER"
 
-JULIA_VER=`${JULIA} -e "using Compat.InteractiveUtils; versioninfo()" | grep "Julia Version"`
+export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+JULIA_VER=`${JULIA} -e "(VERSION > v\"0.7-\") && (import Pkg; Pkg.activate(joinpath(ENV[\"SCRIPT_DIR\"], \"..\"))); using Compat.InteractiveUtils; versioninfo()" | grep "Julia Version"`
 echo $JULIA_VER
 
 ERR=0
@@ -22,40 +23,40 @@ SRC="${DIR}/proto"
 OUT="${DIR}/out"
 WELL_KNOWN_PROTO_SRC="${DIR}/../gen"
 GEN="${PROTOC} --proto_path=${SRC} --proto_path=${WELL_KNOWN_PROTO_SRC} --julia_out=${OUT}"
-CHK="${JULIA} -e"
+CHK="${JULIA} -e '(VERSION > v\"0.7-\") && (import Pkg; Pkg.activate(joinpath(ENV[\"SCRIPT_DIR\"], \"..\")));' -e"
 mkdir -p ${OUT}
 
 cd ${DIR}
-echo "- t1.proto" && ${GEN} ${SRC}/t1.proto && ${CHK} 'include("out/t1_pb.jl")'
+echo "- t1.proto" && ${GEN} ${SRC}/t1.proto && eval " ${CHK} 'include(\"out/t1_pb.jl\")'"
 ERR=$(($ERR + $?))
-echo "- t2.proto" && ${GEN} ${SRC}/t2.proto && ${CHK} 'include("out/t2_pb.jl")'
+echo "- t2.proto" && ${GEN} ${SRC}/t2.proto && eval " ${CHK} 'include(\"out/t2_pb.jl\")'"
 ERR=$(($ERR + $?))
-echo "- recursive.proto" && ${GEN} ${SRC}/recursive.proto && ${CHK} 'include("out/recursive_pb.jl")'
+echo "- recursive.proto" && ${GEN} ${SRC}/recursive.proto && eval " ${CHK} 'include(\"out/recursive_pb.jl\")'"
 ERR=$(($ERR + $?))
-echo "- a.proto, b.proto" && ${GEN} ${SRC}/a.proto ${SRC}/b.proto && ${CHK} 'include("out/AB.jl"); using .AB; using .AB.A, .AB.B'
+echo "- a.proto, b.proto" && ${GEN} ${SRC}/a.proto ${SRC}/b.proto && eval " ${CHK} 'include(\"out/AB.jl\"); using .AB; using .AB.A, .AB.B'"
 ERR=$(($ERR + $?))
-echo "- p1proto.proto, p2proto.proto" && ${GEN} ${SRC}/p1proto.proto ${SRC}/p2proto.proto && ${CHK} 'include("out/P1.jl"); include("out/P2.jl"); using .P1; using .P2'
+echo "- p1proto.proto, p2proto.proto" && ${GEN} ${SRC}/p1proto.proto ${SRC}/p2proto.proto && eval " ${CHK} 'include(\"out/P1.jl\"); include(\"out/P2.jl\"); using .P1; using .P2'"
 ERR=$(($ERR + $?))
-echo "- module_type_name_collision.proto" && JULIA_PROTOBUF_MODULE_POSTFIX=1 ${GEN} ${SRC}/module_type_name_collision.proto && ${CHK} 'include("out/Foo_pb.jl"); using .Foo_pb'
+echo "- module_type_name_collision.proto" && JULIA_PROTOBUF_MODULE_POSTFIX=1 ${GEN} ${SRC}/module_type_name_collision.proto && eval " ${CHK} 'include(\"out/Foo_pb.jl\"); using .Foo_pb'"
 ERR=$(($ERR + $?))
-echo "- packed2.proto" && ${GEN} ${SRC}/packed2.proto && ${CHK} 'include("out/packed2_pb.jl")'
+echo "- packed2.proto" && ${GEN} ${SRC}/packed2.proto && eval " ${CHK} 'include(\"out/packed2_pb.jl\")'"
 ERR=$(($ERR + $?))
 
 if [ ${PROTOC_VER} -eq "3" ]
 then
-    echo "- map3.proto (as dict)" && ${GEN} ${SRC}/map3.proto && ${CHK} 'include("out/map3_pb.jl"); using Compat.Test; @test string(MapTest.types[3].name) == "Dict"'
+    echo "- map3.proto (as dict)" && ${GEN} ${SRC}/map3.proto && eval " ${CHK} 'include(\"out/map3_pb.jl\"); using Compat.Test; @test string(MapTest.types[3].name) == \"Dict\"'"
     ERR=$(($ERR + $?))
     mv out/map3_pb.jl out/map3_dict_pb.jl
-    echo "- map3.proto (as array)" && JULIA_PROTOBUF_MAP_AS_ARRAY=1 ${GEN} ${SRC}/map3.proto && ${CHK} 'include("out/map3_pb.jl"); using Compat.Test; @test string(MapTest.types[3].name) == "Array"'
+    echo "- map3.proto (as array)" && JULIA_PROTOBUF_MAP_AS_ARRAY=1 ${GEN} ${SRC}/map3.proto && eval " ${CHK} 'include(\"out/map3_pb.jl\"); using Compat.Test; @test string(MapTest.types[3].name) == \"Array\"'"
     ERR=$(($ERR + $?))
     mv out/map3_pb.jl out/map3_array_pb.jl
-    echo "- oneof3.proto" && ${GEN} ${SRC}/oneof3.proto && ${CHK} 'include("out/oneof3_pb.jl")'
+    echo "- oneof3.proto" && ${GEN} ${SRC}/oneof3.proto && eval " ${CHK} 'include(\"out/oneof3_pb.jl\")'"
     ERR=$(($ERR + $?))
-    echo "- packed3.proto" && ${GEN} ${SRC}/packed3.proto && ${CHK} 'include("out/packed3_pb.jl")'
+    echo "- packed3.proto" && ${GEN} ${SRC}/packed3.proto && eval " ${CHK} 'include(\"out/packed3_pb.jl\")'"
     ERR=$(($ERR + $?))
-    echo "- any_test.proto" && ${GEN} ${SRC}/any_test.proto && ${CHK} 'include("out/any_test_pb.jl")'
+    echo "- any_test.proto" && ${GEN} ${SRC}/any_test.proto && eval " ${CHK} 'include(\"out/any_test_pb.jl\")'"
     ERR=$(($ERR + $?))
-    echo "- svc3.proto" && ${GEN} ${SRC}/svc3.proto && ${CHK} 'include("out/svc3_pb.jl")'
+    echo "- svc3.proto" && ${GEN} ${SRC}/svc3.proto && eval " ${CHK} 'include(\"out/svc3_pb.jl\")'"
     ERR=$(($ERR + $?))
 fi
 


### PR DESCRIPTION
This makes two changes:
1. Have the script `Pkg.activate` its parent directory (which now
   contains an appropriate Project.toml to make that work). This
   is necessary for things to work if `ProtoBuf` is not installed
   in the top level environment (e.g. it is cloned or a dependency
   in a custom environment).

2. Adds the `ProtoBuf.protoc` command that returns a `Cmd` object
   which is appropriately set up to use the plugin (setting up
   the correct julia version and plugin path).

cc @tanmaykm for review
cc @StefanKarpinski @KristofferC for input on whether there's something better to do with respect to environments here (e.g. for `ProtoBuf.protoc` do we instead somehow want to pass through the environment of the current julia process). 