### PR TITLE
Add a deepcopy override for prototype

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,7 @@
 # utility methods
 
+import Base: deepcopy
+
 isinitialized(obj::Any) = isfilled(obj)
 
 set_field!(obj::Any, fld::Symbol, val) = (setfield!(obj, fld, val); fillset(obj, fld); nothing)
@@ -22,6 +24,12 @@ function copy!(to::T, from::T) where T <: ProtoType
         end
     end
     nothing
+end
+
+function deepcopy(from::T) where { T <: ProtoType }
+    ret = T()
+    copy!(ret, from)
+    ret
 end
 
 function add_field!(obj::Any, fld::Symbol, val)


### PR DESCRIPTION
The current behavior under `deepcopy` is quite counter intuitive. For example,

```
using ProtoBuf

ts = ProtoBuf.google.protobuf.Timestamp()
set_field!(ts, :seconds, 123)
@assert !has_field(ts, :nanos) || ts.nanos == 0
ts2 = deepcopy(ts)
@assert !has_field(ts2, :nanos) || ts2.nanos == 0
```

The second assertion will fail.

Maybe I am misunderstanding something here. But intuitively, after a deepcopy, I would expect the second object is exact the same as the one it copied from. However, in this case the `nanos` field instead got a random number (basically `undef`).