### PR TITLE
correct example in USAGE.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 julia:
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,16 @@ uuid = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 keywords = ["protobuf", "protoc"]
 license = "MIT"
 desc = "Julia protobuf implementation"
+version = "0.8.0"
 
-[deps]
+[compat]
+julia = "≥ 1.0.0"
+
+[extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Serialization", "Test", "Random", "Sockets"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # ProtoBuf.jl
 
 [![Build Status](https://travis-ci.org/JuliaIO/ProtoBuf.jl.png)](https://travis-ci.org/JuliaIO/ProtoBuf.jl)
-[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.3.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.3)
-[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.4.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.4)
-[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.5.svg)](http://pkg.julialang.org/?pkg=ProtoBuf&ver=0.5)
-[![ProtoBuf](http://pkg.julialang.org/badges/ProtoBuf_0.6.svg)](http://pkg.julialang.org/?pkg=ProtoBuf)
 
 [![Coverage Status](https://coveralls.io/repos/github/JuliaIO/ProtoBuf.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaIO/ProtoBuf.jl?branch=master)
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.7.0
+julia 1.0

--- a/USAGE.md
+++ b/USAGE.md
@@ -5,7 +5,7 @@ Reading and writing data structures using ProtoBuf is similar to serialization a
 ````
 julia> using ProtoBuf                       # include protoc generated package here
 
-julia> mutable struct MyType                # a Julia composite type generated from protoc
+julia> mutable struct MyType <: ProtoType   # a Julia composite type generated from protoc
          intval::Int
          strval::String
          MyType(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)


### PR DESCRIPTION
One of the examples in USAGE.md did not mark struct to be a `ProtoType`. fixes #126

Also update Project.toml and travis configuration.