### PR TITLE
Fix parsing of infinity and NaN default values

### DIFF
--- a/test/proto/inf_nan.proto
+++ b/test/proto/inf_nan.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+message InfNan {
+    optional double inf_64 = 1 [default = inf];
+    optional double nan_64 = 2 [default = nan];
+    optional float inf_32 = 3 [default = inf];
+    optional float nan_32 = 4 [default = nan];
+}

--- a/test/testprotoc.sh
+++ b/test/testprotoc.sh
@@ -41,6 +41,8 @@ echo "- module_type_name_collision.proto" && JULIA_PROTOBUF_MODULE_POSTFIX=1 ${G
 ERR=$(($ERR + $?))
 echo "- packed2.proto" && ${GEN} ${SRC}/packed2.proto && eval " ${CHK} 'include(\"out/packed2_pb.jl\")'"
 ERR=$(($ERR + $?))
+echo "- inf_nan.proto" && ${GEN} ${SRC}/inf_nan.proto && eval " ${CHK} 'include(\"out/inf_nan_pb.jl\")'"
+ERR=$(($ERR + $?))
 
 if [ ${PROTOC_VER} -eq "3" ]
 then


### PR DESCRIPTION
Previously these would appear unchanged in the Julia code (e.g., as
"inf" and "nan" literally) and therefore the resulting code would not
compile.

Ref https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#floating-point-literals