### PR TITLE
update package and code generator for thread safety, few other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: julia
 julia:
-  - 1.0
-  - 1.1
-  - 1.2
   - 1.3
+  - 1.4
+  - 1.5
   - nightly
 notifications:
   email: false

--- a/PROTOC.md
+++ b/PROTOC.md
@@ -38,9 +38,9 @@ Using the following cmd (without spaces around the equality sign)
 `protoc -I=<Folder with .proto-Files> --plugin=protoc-gen-julia=<Absolute PATH to protoc-gen-julia-File>\protoc-gen-julia_win.bat --julia_out=<Existing Folder where generated .jl files will be stored>   <Path of proto-Files which you want to compile>`
 
 Example for .proto-files located in fhe folder `test\proto`:
-`cd C:\Users\<Username>\.julia\v0.6\ProtoBuf\test`
+`cd ProtoBuf\test`
 
-`protoc -I=proto    --plugin=protoc-gen-julia=C:\Users\UELIWECH\.julia\v0.6\ProtoBuf\plugin\protoc-gen-julia_win.bat --julia_out=jlout proto/PROTOFILENAME.proto`
+`protoc -I=proto --plugin=protoc-gen-julia=ProtoBuf\plugin\protoc-gen-julia_win.bat --julia_out=jlout proto/PROTOFILENAME.proto`
 
 
 If you want to set the system parameter (as mentioned above) use the following commands (it is important have not whitespaces around the equality sign):
@@ -50,9 +50,6 @@ If you want to set the system parameter (as mentioned above) use the following c
 
 You can test if it is set correctly by using the echo call.
 `echo %Variable_Name%`
-
-
-
 
 
 ### Julia Type Mapping
@@ -113,4 +110,4 @@ Service stubs are Julia types. Stubs can be constructed by passing an RPC channe
 
 - Extensions are not supported yet.
 - Groups are not supported. They are deprecated anyway.
-- Enums are declared as `Int32` types in the generated code, but a separate Julia type is generated with fields same as the enum values which can be used for validation. The types representing enums extend from the abstract type `ProtoEnum` and the `lookup` method can be used to verify valid values.
+- Enums are declared as `Int32` types in the generated code. For every enum, a separate named tuple is generated with fields matching the enum values. The `lookup` method can be used to verify valid values.

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,10 @@ uuid = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 keywords = ["protobuf", "protoc"]
 license = "MIT"
 desc = "Julia protobuf implementation"
-version = "0.8.0"
+version = "0.9.0"
+
+[deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
 julia = "1"

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,76 +1,75 @@
 ## Using ProtoBuf
 
+Julia code for protobuf message types can be generated via protoc (see ["Generating Julia Code from .proto Specifications"](PROTOC.md)). Generated Julia code for a protobuf message look something like:
+
+```julia
+mutable struct Description <: ProtoType
+    # a bunch of internal fields
+    ...
+    function Description(; kwargs...)
+        # code to initialize the internal fields
+    end
+end # mutable struct Description
+const __meta_Description = Ref{ProtoMeta}()
+function meta(::Type{Description})
+    # code to initialize the metadata
+    __meta_Description[]
+end
+function Base.getproperty(obj::Description, name::Symbol)
+    # code to get properties
+end
+```
+
 Reading and writing data structures using ProtoBuf is similar to serialization and deserialization. Methods `writeproto` and `readproto` can write and read Julia types from IO streams.
 
 ````
 julia> using ProtoBuf                       # include protoc generated package here
 
-julia> mutable struct MyType <: ProtoType   # a Julia composite type generated from protoc
-         intval::Int
-         strval::String
-         MyType(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+julia> mutable struct MyType <: ProtoType   # a Julia composite type generated from protoc that
+         ...                                # has intval::Int and strval::String as properties
+         function MyType(; kwargs...)
+             ...
+         end
        end
+       ...
 
 julia> iob = PipeBuffer();
 
-julia> writeproto(iob, MyType(intval=10, strval="hello world"));   # write an instance of it
+julia> writeproto(iob, MyType(; intval=10, strval="hello world"));   # write an instance of it
 
-julia> readproto(iob, MyType())  # read it back into another instance
-MyType(10,"hello world")
-````
+julia> data = readproto(iob, MyType());  # read it back into another instance
 
-## Protocol Buffer Metadata
+julia> data.intval
+10
 
-ProtoBuf serialization can be customized for a type by defining a `meta` method on it. The `meta` method provides an instance of `ProtoMeta` that allows specification of mandatory fields, field numbers, and default values for fields for a type. Defining a specialized `meta` is done simply as below:
-
-````
-import ProtoBuf.meta
-
-meta(t::Type{MyType}) = meta(t,                          # the type which this is for
-		Symbol[:intval],                                 # required fields
-		Int[8, 10],                                      # field numbers
-		Dict{Symbol,Any}(:strval => "default value"))  # default values
-````
-
-Without any specialized `meta` method:
-
-- All fields are marked as optional (or repeating for arrays)
-- Numeric fields have zero as default value
-- String fields have `""` as default value
-- Field numbers are assigned serially starting from 1, in the order of their declaration.
-
-For the things where the default is what you need, just passing empty values would do. E.g., if you just want to specify the field numbers, this would do:
-
-````
-meta(t::Type{MyType}) = meta(t, [], [8,10], Dict())
+julia> data.strval
+"hello world"
 ````
 
 ## Setting and Getting Fields
-Types used as protocol buffer structures are regular Julia types and the Julia syntax to set and get fields can be used on them. But with fields that are set as optional, it is quite likely that some of them may not have been present in the instance that was read. The following methods are exported to assist doing this:
 
-- `get_field(obj::Any, fld::Symbol)` : Gets `obj.fld` if it has been set. Throws an error otherwise.
-- `has_field(obj::Any, fld::Symbol)` : Checks whether field `fld` has been set in `obj`.
-- `clear(obj::Any, fld::Symbol)` : Marks field `fld` of `obj` as unset.
-- `clear(obj::Any)` : Marks all fields of `obj` as unset.
+Types used as protocol buffer structures are regular Julia types and the Julia syntax to set and get fields can be used on them. The generated type constructor makes it easier to set large types with many fields by passing name value pairs during construction: `T(; name=val...)`.
 
-The `protobuild` method makes it easier to set large types with many fields:
-- `protobuild{T}(::Type{T}, nvpairs::Dict{Symbol}()=Dict{Symbol,Any}())`
+Fields that are marked as optional may not be present in an instance of the struct that is read. Also, you may want to clear a set property from an instance. The following methods are exported to assist doing this:
 
-Types generated through the Julia protoc plugin generates constructors that use `protobuild` and expect keyword arguments for the type members.
+- `propertynames(obj)` : Returns a list of property names possible
+- `setproperty!(obj, fld::Symbol, v)` : Sets `obj.fld`.
+- `getproperty(obj, fld::Symbol)` : Gets `obj.fld` if it has been set. Throws an error otherwise.
+- `hasproperty(obj, fld::Symbol)` : Checks whether property `fld` has been set in `obj`.
+- `clear(obj, fld::Symbol)` : clears property `fld` of `obj`.
+- `clear(obj)` : Clears all properties of `obj`.
 
 ````
 julia> using ProtoBuf
 
 julia> mutable struct MyType <: ProtoType  # a Julia composite type
-           intval::Int
-           # fillunset (documented below is similar to clear)
-           # ProtoBuf._protobuild is an internal method similar to protobuild
-           MyType(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+           ... # intval::Int
+           ...
        end
 
 julia> mutable struct OptType <: ProtoType # and another one to contain it
-           opt::MyType
-           OptType(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+           ... #opt::MyType
+           ...
        end
 
 julia> iob = PipeBuffer();
@@ -79,19 +78,16 @@ julia> writeproto(iob, OptType(opt=MyType(intval=10)));
 
 julia> readval = readproto(iob, OptType());
 
-julia> has_field(readval, :opt)       # valid this time
+julia> hasproperty(readval, :opt)
 true
 
 julia> writeproto(iob, OptType());
 
 julia> readval = readproto(iob, OptType());
 
-julia> has_field(readval, :opt)       # but not valid now
+julia> hasproperty(readval, :opt)
 false
 ````
-
-Note: The constructor for types generated by the `protoc` compiler have a call to `clear` to mark all fields of the object as unset to start with. A similar call must be made explicitly while using Julia types that are not generated. Otherwise any defined field in an instance is assumed to be valid.
-
 
 The `isinitialized(obj::Any)` method checks whether all mandatory fields are set. It is useful to check objects using this method before sending them. Method `writeproto` results in an exception if this condition is violated.
 
@@ -101,45 +97,34 @@ julia> using ProtoBuf
 julia> import ProtoBuf.meta
 
 julia> mutable struct TestType <: ProtoType
-           val::Any
+           ... # val::Any
+           ...
        end
 
 julia> mutable struct TestFilled <: ProtoType
-           fld1::TestType
-           fld2::TestType
-           TestFilled(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+           ... # fld1::TestType (mandatory)
+           ... # fld2::TestType
+           ...
        end
 
-julia> meta(t::Type{TestFilled}) = meta(t, Symbol[:fld1], Int[], Dict{Symbol,Any}());
-
-julia> tf = TestFilled()
-TestFilled(#undef,#undef)
+julia> tf = TestFilled();
 
 julia> isinitialized(tf)      # false, since fld1 is not set
 false
 
-julia> tf.fld1 = TestType("");
+julia> tf.fld1 = TestType(fld1="");
 
 julia> isinitialized(tf)      # true, even though fld2 is not set yet
 true
 ````
 
 ## Equality &amp; Hash Value
-It is possible for fields marked as optional to be in an &quot;unset&quot; state. Even bits type fields (`isbitstype(T) == true`) can be in this state though they may have valid contents. Such fields should then not be compared for equality or used for computing hash values. All ProtoBuf compatible types, by virtue of extending abstract `ProtoType` type, override `hash`, `isequal` and `==` methods to handle this. The following unexported utility methods can be used for this purpose, in cases where it is not possible to extend `ProtoType`:
-
-- `protohash(v)` : hash method that considers fill status of types
-- `protoeq{T}(v1::T, v2::T)` : equality method that considers fill status of types
-- `protoisequal{T}(v1::T, v2::T)` : isequal method that considers fill status of types
+It is possible for fields marked as optional to be in an &quot;unset&quot; state. Even bits type fields (`isbitstype(T) == true`) can be in this state though they may have valid contents. Such fields should then not be compared for equality or used for computing hash values. All ProtoBuf compatible types, by virtue of extending abstract `ProtoType` type, override `hash`, `isequal` and `==` methods to handle this. 
 
 ## Other Methods
 - `copy!{T}(to::T, from::T)` : shallow copy of objects
-- `isfilled(obj, fld::Symbol)` : same as `has_field`
 - `isfilled(obj)` : same as `isinitialized`
-- `isfilled_default(obj, fld::Symbol)` : whether field is set with default value (and not deserialized)
-- `fillset(obj, fld::Symbol)` : mark field fld of object obj as set
-- `fillunset(obj)` : mark all fields of this object as not set
-- `fillunset(obj::Any, fld::Symbol)` : mark field fld of object obj as not set
-- `lookup(en::ProtoEnum,val::Integer)` : lookup the name (symbol) corresponding to an enum value
+- `lookup(en, val::Integer)` : lookup the name (symbol) corresponding to an enum value
 - `enumstr(enumname, enumvalue::Int32)`: returns a string with the enum field name matching the value
 - `which_oneof(obj, oneof::Symbol)`: returns a symbol indicating the name of the field in the `oneof` group that is filled
 

--- a/plugin/protoc-gen-julia
+++ b/plugin/protoc-gen-julia
@@ -15,9 +15,13 @@ if [ ${JULIA_PROTOBUF_MAP_AS_ARRAY:-0} -eq 1 ]; then
     FLAGS="${FLAGS} --map-as-array"
 fi
 
+if [ ${JULIA_PROTOBUF_DEBUG:-0} -eq 1 ]; then
+    FLAGS="${FLAGS} --debug-gen"
+fi
+
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 JULIA_GEN="${JULIA} ${COVERAGE} --project=${SCRIPT_DIR}/.. -e 'using ProtoBuf; using ProtoBuf.Gen; gen()'"
-if [ -z ${FLAGS} ]
+if [ -z "${FLAGS}" ]
 then
     eval " ${JULIA_GEN}"
 else

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -4,7 +4,7 @@ import Base: setproperty!, show, copy!, deepcopy, hash, isequal, ==
 
 export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta, protobuild
 export filled, isfilled, isfilled_default, which_oneof, fillset, fillset_default, fillunset
-export setproperty!, show, copy!, deepcopy, get_field, clear, add_field!, has_field, isinitialized
+export setproperty!, show, copy!, deepcopy, get_field, clear, has_field, isinitialized
 export hash, isequal, ==
 export ProtoEnum, ProtoType, lookup, enumstr
 export ProtoServiceException, ProtoRpcChannel, ProtoRpcController, MethodDescriptor, ServiceDescriptor, ProtoService,

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -1,18 +1,15 @@
 module ProtoBuf
 
-import Base: setproperty!, show, copy!, deepcopy, hash, isequal, ==
+import Base: setproperty!, getproperty, hasproperty, propertynames, show, copy!, deepcopy, hash, isequal, ==
 
-export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta, protobuild
-export filled, isfilled, isfilled_default, which_oneof, fillset, fillset_default, fillunset
-export setproperty!, show, copy!, deepcopy, get_field, clear, has_field, isinitialized
+export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta
+export isfilled, which_oneof
+export setproperty!, getproperty, hasproperty, show, copy!, deepcopy, clear, isinitialized
 export hash, isequal, ==
 export ProtoEnum, ProtoType, lookup, enumstr
 export ProtoServiceException, ProtoRpcChannel, ProtoRpcController, MethodDescriptor, ServiceDescriptor, ProtoService,
        AbstractProtoServiceStub, GenericProtoServiceStub, ProtoServiceStub, ProtoServiceBlockingStub,
        find_method, get_request_type, get_response_type, get_descriptor_for_type, call_method
-
-fld_type(o::T, fld) where {T} = fieldtype(T, fld)
-fld_names(x) = x.name.names
 
 include("codec.jl")
 include("svc.jl")

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -4,7 +4,7 @@ import Base: setproperty!, show, copy!, deepcopy, hash, isequal, ==
 
 export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta, protobuild
 export filled, isfilled, isfilled_default, which_oneof, fillset, fillset_default, fillunset
-export setproperty!, show, copy!, deepcopy, set_field, set_field!, get_field, clear, add_field, add_field!, has_field, isinitialized
+export setproperty!, show, copy!, deepcopy, get_field, clear, add_field!, has_field, isinitialized
 export hash, isequal, ==
 export ProtoEnum, ProtoType, lookup, enumstr
 export ProtoServiceException, ProtoRpcChannel, ProtoRpcController, MethodDescriptor, ServiceDescriptor, ProtoService,

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -36,7 +36,6 @@ defaultval(::Type{Bool})                            = [false]
 defaultval(::Type{Vector{T}}) where {T}             = Any[T[]]
 defaultval(::Type)                                  = []
 
-
 function _write_uleb(io::IO, x::T) where T <: Integer
     nw = 0
     cont = true
@@ -107,7 +106,6 @@ function _read_zigzag(io::IO, ::Type{T}) where T <: Integer
     convert(T, iseven(zx) ? (zx >>> 1) : -signed((zx+1) >>> 1))
 end
 
-
 ##
 # read and write field keys
 _write_key(io::IO, fld::Int, wiretyp::Int) = _write_uleb(io, (fld << 3) | wiretyp)
@@ -117,7 +115,6 @@ function _read_key(io::IO)
     fld = key >>> 3
     (fld, wiretyp)
 end
-
 
 ##
 # read and write field values
@@ -260,8 +257,9 @@ const WIRETYPES = Dict{Symbol,Tuple}(
 
 mutable struct ProtoMetaAttribs
     fldnum::Int             # the field number in the structure
-    fld::Symbol
+    fld::Symbol             # field name
     ptyp::Symbol            # protobuf type
+    jtyp::Type              # Julia type
     occurrence::Int         # 0: optional, 1: required, 2: repeated
     packed::Bool            # if repeated, whether packed
     default::Array          # the default value, empty array if none is specified, first element is used if something is specified
@@ -276,10 +274,16 @@ mutable struct ProtoMeta
     oneofs::Vector{Int}
     oneof_names::Vector{Symbol}
 
-    ProtoMeta(jtype::Type, ordered::Vector{ProtoMetaAttribs}, oneofs::Vector{Int}=Int[], oneof_names::Vector{Symbol}=Symbol[]) = _setmeta(new(), jtype, ordered, oneofs, oneof_names)
+    function ProtoMeta(jtype::Type, ordered::Vector{ProtoMetaAttribs}, oneofs::Vector{Int}=Int[], oneof_names::Vector{Symbol}=Symbol[])
+        setprotometa!(new(), jtype, ordered, oneofs, oneof_names)
+    end
+
+    function ProtoMeta(jtype::Type)
+        new(jtype)
+    end
 end
 
-function _setmeta(meta::ProtoMeta, jtype::Type, ordered::Vector{ProtoMetaAttribs}, oneofs::Vector{Int}, oneof_names::Vector{Symbol})
+function setprotometa!(meta::ProtoMeta, jtype::Type, ordered::Vector{ProtoMetaAttribs}, oneofs::Vector{Int}, oneof_names::Vector{Symbol})
     symdict = Dict{Symbol,ProtoMetaAttribs}()
     numdict = Dict{Int,ProtoMetaAttribs}()
     for attrib in ordered
@@ -361,7 +365,7 @@ function writeproto(io::IO, val::Array{T}, attrib::ProtoMetaAttribs, wfn::F) whe
     (attrib.occurrence == 2) || error("expected meta attributes of $(attrib.fld) to specify an array")
     if attrib.packed
         # write elements as a length delimited field
-        if ptyp == :obj
+        if ptyp === :obj
             error("can not write object field $fld as packed")
         else
             for eachval in val
@@ -373,7 +377,7 @@ function writeproto(io::IO, val::Array{T}, attrib::ProtoMetaAttribs, wfn::F) whe
     else
         # write each element separately
         # maps can not be repeated
-        if ptyp == :obj
+        if ptyp === :obj
             for eachval in val
                 wfn(iob, convert(jtyp, eachval), meta)
                 n += _write_key(io, fld, WIRETYP_LENDELIM)
@@ -394,9 +398,9 @@ function writeproto(io::IO, obj, meta::ProtoMeta=meta(typeof(obj)))
     @debug("writeproto writing an obj", meta)
     for attrib in meta.ordered
         fld = attrib.fld
-        if isfilled(obj, fld)
+        if hasproperty(obj, fld)
             @debug("writeproto", field=fld)
-            n += writeproto(io, getfield(obj, fld), attrib)
+            n += writeproto(io, getproperty(obj, fld), attrib)
         else
             @debug("not set", field=fld)
             (attrib.occurrence == 1) && error("missing required field $fld (#$(attrib.fldnum))")
@@ -421,7 +425,7 @@ function read_lendelim_obj(io, val, meta::ProtoMeta, reader)
 end
 
 instantiate(t::Type) = ccall(:jl_new_struct_uninit, Any, (Any,), t)
-instantiate(t::T) where {T <: ProtoType} = T()
+instantiate(t::Type{T}) where {T <: ProtoType} = T()
 
 function skip_field(io::IO, wiretype::Integer)
     if wiretype == WIRETYP_LENDELIM
@@ -445,21 +449,21 @@ function read_field(io, container, attrib::ProtoMetaAttribs, wiretyp, jtyp_speci
 
     if jtyp_specific !== nothing
         jtyp = jtyp_specific
-    elseif ptyp == :obj
+    elseif ptyp === :obj
         jtyp = attrib.meta.jtype
-    elseif ptyp == :map
+    elseif ptyp === :map
         jtyp = attrib.meta.jtype
     end
 
     if isrepeat
-        arr_val = ((container !== nothing) && isdefined(container, fld)) ? convert(Vector{jtyp}, getfield(container, fld)) : jtyp[]
+        arr_val = ((container !== nothing) && hasproperty(container, fld)) ? convert(Vector{jtyp}, getproperty(container, fld)) : jtyp[]
         # Readers should accept repeated fields in both packed and expanded form.
         # Allows compatibility with old writers when [packed = true] is added later.
         # Only repeated fields of primitive numeric types (isbitstype == true) can be declared "packed".
         # Maps can not be repeated
         if isbitstype(jtyp) && (wiretyp == WIRETYP_LENDELIM)
             read_lendelim_packed(io, arr_val, rfn, jtyp)
-        elseif ptyp == :obj
+        elseif ptyp === :obj
             push!(arr_val, read_lendelim_obj(io, instantiate(jtyp), attrib.meta, rfn))
         else
             push!(arr_val, rfn(io, jtyp))
@@ -468,11 +472,11 @@ function read_field(io, container, attrib::ProtoMetaAttribs, wiretyp, jtyp_speci
     else
         (wiretyp != _wiretyp) && !isrepeat && error("cannot read wire type $wiretyp as $ptyp")
 
-        if ptyp == :obj
-            val_obj = ((container !== nothing) && isdefined(container, fld)) ? getfield(container, fld) : instantiate(jtyp)
+        if ptyp === :obj
+            val_obj = ((container !== nothing) && hasproperty(container, fld)) ? getproperty(container, fld) : instantiate(jtyp)
             return read_lendelim_obj(io, val_obj, attrib.meta, rfn)
-        elseif ptyp == :map
-            val_map = ((container !== nothing) && isdefined(container, fld)) ? convert(jtyp, getfield(container, fld)) : jtyp()
+        elseif ptyp === :map
+            val_map = ((container !== nothing) && hasproperty(container, fld)) ? convert(jtyp, getproperty(container, fld)) : jtyp()
             return read_map(io, val_map)
         else
             @debug("reading", jtyp)
@@ -483,56 +487,51 @@ end
 
 function readproto(io::IO, obj, meta::ProtoMeta=meta(typeof(obj)))
     @debug("readproto begin", typ=typeof(obj))
-    fillunset(obj)
-    fldnums = collect(keys(meta.numdict))
+    clear(obj)
     while !eof(io)
         fldnum, wiretyp = _read_key(io)
         @debug("reading", typ=typeof(obj), fldnum)
 
         fldnum = Int(fldnum)
+        attrib = get(meta.numdict, fldnum, nothing)
+
         # ignore unknown fields
-        if !(fldnum in fldnums)
+        if attrib === nothing
             @debug("skipping unknown field", typ=typeof(obj), fldnum)
             skip_field(io, wiretyp)
             continue
         end
-        attrib = meta.numdict[fldnum]
 
         val = read_field(io, obj, attrib, wiretyp, nothing)
         fld = attrib.fld
-        fillset(obj, fld)
-        if (attrib.occurrence == 2) || (attrib.ptyp == :obj) || (attrib.ptyp == :map)
-            setfield!(obj, fld, convert(fld_type(obj, fld), val))
+        if (attrib.occurrence == 2) || (attrib.ptyp === :obj) || (attrib.ptyp === :map)
+            setproperty!(obj, fld, convert(attrib.jtyp, val))
         else
-            setfield!(obj, fld, val)
+            setproperty!(obj, fld, val)
         end
     end
 
-    # populate defaults
-    fnames = fld_names(typeof(obj))
-    fill = filled(obj)
-    for attrib in meta.ordered
-        fld = attrib.fld
-        idx = something(findfirst(isequal(fld), fnames))
-        # TODO: do not fill if oneof the fields in the oneof
-        if !isfilled(obj, fld) && (length(attrib.default) > 0) && !_isset_oneof(fill, meta.oneofs, idx)
-            default = attrib.default[1]
-            setfield!(obj, fld, convert(fld_type(obj, fld), deepcopy(default)))
-            @debug("readproto set default", typ=typeof(obj), fld, default)
-            fillset_default(obj, fld)
-        end
-    end
+    setdefaultproperties!(obj, meta)
     @debug("readproto end", typ=typeof(obj))
+
     obj
 end
 
+function setdefaultproperties!(obj::ProtoType, meta::ProtoMeta=meta(typeof(obj)))
+    for (idx,attrib) in enumerate(meta.ordered)
+        fld = attrib.fld
+        # TODO: do not fill if oneof the fields in the oneof
+        if !hasproperty(obj, fld) && !isempty(attrib.default) && !_isset_oneof(obj, idx)
+            default = attrib.default[1]
+            setproperty!(obj, fld, convert(attrib.jtyp, deepcopy(default)))
+            @debug("readproto set default", typ=typeof(obj), fld, default)
+        end
+    end
+    obj
+ end
 
 ##
 # helpers
-const _metacache = IdDict() # dict of Type => ProtoMeta
-const _mapentry_metacache = IdDict()
-const _fillcache = Dict{UInt,BitArray{2}}()
-
 const DEF_REQ = Symbol[]
 const DEF_FNUM = Int[]
 const DEF_VAL = Dict{Symbol,Any}()
@@ -542,29 +541,15 @@ const DEF_ONEOFS = Int[]
 const DEF_ONEOF_NAMES = Symbol[]
 const DEF_FIELD_TYPES = Dict{Symbol,String}()
 
-meta(typ::Type) = haskey(_metacache, typ) ? _metacache[typ] : meta(typ, DEF_REQ, DEF_FNUM, DEF_VAL, true, DEF_PACK, DEF_WTYPES, DEF_ONEOFS, DEF_ONEOF_NAMES, DEF_FIELD_TYPES)
-function meta(typ::Type, required::Array, numbers::Array, defaults::Dict, cache::Bool=true, pack::Array=DEF_PACK, wtypes::Dict=DEF_WTYPES,
-                oneofs::Vector{Int}=DEF_ONEOFS, oneof_names::Vector{Symbol}=DEF_ONEOF_NAMES, field_types::Dict{Symbol,String}=DEF_FIELD_TYPES)
-    haskey(_metacache, typ) && return _metacache[typ]
-    d = Dict{Symbol,Any}()
-    for (k,v) in defaults
-        d[k] = v
-    end
-    meta(typ, convert(Vector{Symbol}, required), convert(Vector{Int}, numbers), d, cache, convert(Vector{Symbol}, pack), wtypes, oneofs, oneof_names, field_types)
-end
-function meta(typ::Type, required::Vector{Symbol}, numbers::Vector{Int}, defaults::Dict{Symbol,Any}, cache::Bool=true, pack::Vector{Symbol}=DEF_PACK,
-                wtypes::Dict=DEF_WTYPES, oneofs::Vector{Int}=DEF_ONEOFS, oneof_names::Vector{Symbol}=DEF_ONEOF_NAMES, field_types::Dict{Symbol,String}=DEF_FIELD_TYPES)
-    haskey(_metacache, typ) && return _metacache[typ]
+_resolve_type(relativeto::Type, typ::Type) = typ
+_resolve_type(relativeto::Type, typ::String) = Core.eval(relativeto.name.module, Meta.parse(typ))
 
-    m = ProtoMeta(typ, ProtoMetaAttribs[])
-    cache && (_metacache[typ] = m)
-
+function meta(target::ProtoMeta, typ::Type, all_fields::Vector{Pair{Symbol,Union{Type,String}}}, required::Vector{Symbol}, numbers::Vector{Int}, defaults::Dict{Symbol,Any},
+        pack::Vector{Symbol}=DEF_PACK, wtypes::Dict=DEF_WTYPES, oneofs::Vector{Int}=DEF_ONEOFS, oneof_names::Vector{Symbol}=DEF_ONEOF_NAMES)
     attribs = ProtoMetaAttribs[]
-    names = fld_names(typ)
-    types = typ.types
-    for fldidx in 1:length(names)
-        fldname = names[fldidx]
-        fldtyp = (fldname in keys(field_types)) ? Core.eval(typ.name.module, Meta.parse(field_types[fldname])) : types[fldidx]
+    for fldidx in 1:length(all_fields)
+        fldname = first(all_fields[fldidx])
+        fldtyp = _resolve_type(typ, last(all_fields[fldidx]))
         fldnum = isempty(numbers) ? fldidx : numbers[fldidx]
         isarr = (fldtyp <: Array) && !(fldtyp === Vector{UInt8})
         repeat = isarr ? 2 : (fldname in required) ? 1 : 0
@@ -576,18 +561,15 @@ function meta(typ::Type, required::Vector{Symbol}, numbers::Vector{Int}, default
 
         fldmeta = (wtyp == :obj) ? meta(elemtyp) :
                   (wtyp == :map) ? mapentry_meta(elemtyp) : nothing
-        push!(attribs, ProtoMetaAttribs(fldnum, fldname, wtyp, repeat, packed, default, fldmeta))
+        push!(attribs, ProtoMetaAttribs(fldnum, fldname, wtyp, fldtyp, repeat, packed, default, fldmeta))
     end
-    _setmeta(m, typ, attribs, oneofs, oneof_names)
-    m
+    setprotometa!(target, typ, attribs, oneofs, oneof_names)
 end
 
 function mapentry_meta(typ::Type{Dict{K,V}}) where {K,V}
-    m = ProtoMeta(typ, ProtoMetaAttribs[])
-    _mapentry_metacache[typ] = m
-
+    target = ProtoMeta(typ)
     attribs = ProtoMetaAttribs[]
-    push!(attribs, ProtoMetaAttribs(1, :key, wiretype(K), 0, false, defaultval(K), nothing))
+    push!(attribs, ProtoMetaAttribs(1, :key, wiretype(K), K, 0, false, defaultval(K), nothing))
 
     isarr = (V <: Array) && !(V === Vector{UInt8})
     repeat = isarr ? 2 : 0
@@ -595,103 +577,65 @@ function mapentry_meta(typ::Type{Dict{K,V}}) where {K,V}
     wtyp = wiretype(V)
     vmeta = (wtyp == :obj) ? meta(V) :
             (wtyp == :map) ? mapentry_meta(V) : nothing
-    push!(attribs, ProtoMetaAttribs(2, :value, wtyp, repeat, packed, defaultval(V), vmeta))
+    push!(attribs, ProtoMetaAttribs(2, :value, wtyp, V, repeat, packed, defaultval(V), vmeta))
 
-    _setmeta(m, typ, attribs, DEF_ONEOFS, DEF_ONEOF_NAMES)
-    m
-end
-
-function _unset_oneofs(fill::BitArray{2}, oneofs::Vector{Int}, idx::Int)
-    oneofidx = isempty(oneofs) ? 0 : oneofs[idx]
-    if oneofidx > 0
-        # unset other fields in the oneof group
-        for uidx = 1:length(oneofs)
-            if (oneofs[uidx] == oneofidx) && (uidx !== idx)
-                fill[1:2,uidx] .= false
-            end
-        end
-    end
-end
-
-function _isset_oneof(fill::BitArray{2}, oneofs::Vector{Int}, idx::Int)
-    oneofidx = isempty(oneofs) ? 0 : oneofs[idx]
-    if oneofidx > 0
-        # find if any field in the oneof group is set
-        for uidx = 1:length(oneofs)
-            if oneofs[uidx] == oneofidx
-                fill[1,uidx] && (return true)
-            end
-        end
-    end
-    false
-end
-
-fillunset(obj) = (fill!(filled(obj), false); nothing)
-fillunset(obj, fld::Symbol) = _fillset(obj, fld, false, false)
-fillset(obj, fld::Symbol) = _fillset(obj, fld, true, false)
-fillset_default(obj, fld::Symbol) = _fillset(obj, fld, true, true)
-function _fillset(obj, fld::Symbol, val::Bool, isdefault::Bool)
-    fill = filled(obj)
-    fnames = fld_names(typeof(obj))
-    idx = something(findfirst(isequal(fld), fnames))
-    fill[1,idx] = val
-    (!val || isdefault) && (fill[2,idx] = val)
-    val && _unset_oneofs(fill, meta(typeof(obj)).oneofs, idx)
-    nothing
-end
-
-function filled(obj)
-    oid = objectid(obj)
-    haskey(_fillcache, oid) && return _fillcache[oid]
-
-    fnames = fld_names(typeof(obj))
-    fill = fill!(BitArray(undef, 2, length(fnames)), false)
-    oneofs = meta(typeof(obj)).oneofs
-    for idx in 1:length(fnames)
-        if isdefined(obj, fnames[idx])
-            fill[1,idx] = true
-            _unset_oneofs(fill, oneofs, idx)
-        end
-    end
-    if !isimmutable(obj)
-        _fillcache[oid] = fill
-        finalizer(obj->delete!(_fillcache, objectid(obj)), obj)
-    end
-    fill
-end
-
-isfilled(obj, fld::Symbol) = _isfilled(obj, fld, false)
-isfilled_default(obj, fld::Symbol) = _isfilled(obj, fld, true)
-function _isfilled(obj, fld::Symbol, isdefault::Bool)
-    fnames = fld_names(typeof(obj))
-    idx = something(findfirst(isequal(fld), fnames))
-    filled(obj)[isdefault ? 2 : 1, idx]
+    setprotometa!(target, typ, attribs, DEF_ONEOFS, DEF_ONEOF_NAMES)
 end
 
 function isfilled(obj)
-    fill = filled(obj)
-    flds = meta(typeof(obj)).ordered
-    for idx in 1:length(flds)
-        fld = flds[idx]
-        if fld.occurrence == 1
-            fill[1,idx] || (return false)
-            (fld.meta != nothing) && !isfilled(getfield(obj, fld.fld)) && (return false)
+    fldattribs = meta(typeof(obj)).ordered
+    for idx in 1:length(fldattribs)
+        fldattrib = fldattribs[idx]
+        if fldattrib.occurrence == 1
+            fldname = fldattrib.fld
+            hasproperty(obj, fldname) || (return false)
+            (fldattrib.meta !== nothing) && !isfilled(getproperty(obj, fldname)) && (return false)
         end
     end
     true
 end
 
+function _isset_oneof(obj, idx::Int)
+    m = meta(typeof(obj))
+    oneofs = m.oneofs
+    oneof_idx = isempty(oneofs) ? 0 : oneofs[idx]
+    (oneof_idx > 0) || (return false)
+    _which_oneof(obj, m, oneof_idx) !== Symbol()
+end
+
 function which_oneof(obj, oneof::Symbol)
     m = meta(typeof(obj))
-    fill = filled(obj)
-    fnames = fld_names(typeof(obj))
-    oneofs = m.oneofs
     oneof_idx = something(findfirst(isequal(oneof), m.oneof_names))
+    _which_oneof(obj, m, oneof_idx)
+end
 
+function _which_oneof(obj, m, oneof_idx)
+    oneofs = m.oneofs
     for idx in 1:length(oneofs)
-        (oneofs[idx] == oneof_idx) && fill[1,idx] && (return fnames[idx])
+        if oneofs[idx] == oneof_idx
+            fldname = m.ordered[idx].fld
+            hasproperty(obj, fldname) && (return fldname)
+        end
     end
     Symbol()
+end
+
+function _unset_oneof(obj, objmeta, fld)
+    if !isempty(objmeta.oneofs)
+        fldidx = 1
+        while fldidx <= length(objmeta.ordered)
+            if objmeta.ordered[fldidx].fld === fld
+                break
+            else
+                fldidx += 1
+            end
+        end
+        nameidx = objmeta.oneofs[fldidx]
+        if nameidx > 0
+            oneofprop = which_oneof(obj, objmeta.oneof_names[nameidx])
+            (oneofprop === Symbol()) || clear(obj, oneofprop)
+        end
+    end
 end
 
 function show(io::IO, m::ProtoMeta)
@@ -699,19 +643,32 @@ function show(io::IO, m::ProtoMeta)
     println(io, m.ordered)
 end
 
+propertynames(obj::ProtoType) = [attrib.fld for attrib in obj.__protobuf_jl_internal_meta.ordered]
+hasproperty(obj::ProtoType, fld::Symbol) = haskey(obj.__protobuf_jl_internal_values, fld)
+function setproperty!(obj::ProtoType, fld::Symbol, val)
+    objmeta = obj.__protobuf_jl_internal_meta
+    symdict = objmeta.symdict
+    if fld in keys(symdict)
+        _unset_oneof(obj, objmeta, fld)
+        fldtype = symdict[fld].jtyp
+        obj.__protobuf_jl_internal_values[fld] = isa(val, fldtype) ? val : convert(fldtype, val)
+    else
+        setfield!(obj, fld, val)
+    end
+end
+
+function clear(obj::ProtoType)
+    empty!(obj.__protobuf_jl_internal_values)
+    nothing
+end
+
+function clear(obj::ProtoType, fld::Symbol)
+    delete!(obj.__protobuf_jl_internal_values, fld)
+    nothing
+end
 
 ##
 # Enum Lookup
-
-abstract type ProtoEnum end
-
-function lookup(en::ProtoEnum, val)
-    for name in fld_names(typeof(en))
-        (val == getfield(en, name)) && return name
-    end
-    error("Enum $(typeof(en)) has no value: $val")
-end
-
 function lookup(en::T, val) where {T <: NamedTuple}
     for name in propertynames(en)
         (val == getproperty(en, name)) && return name

--- a/src/codec.jl
+++ b/src/codec.jl
@@ -712,3 +712,10 @@ function lookup(en::ProtoEnum, val)
     end
     error("Enum $(typeof(en)) has no value: $val")
 end
+
+function lookup(en::T, val) where {T <: NamedTuple}
+    for name in propertynames(en)
+        (val == getproperty(en, name)) && return name
+    end
+    error("Enum has no value $val")
+end

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -283,17 +283,13 @@ function generate_enum(io::IO, errio::IO, enumtype::EnumDescriptorProto, scope::
     push!(scope.syms, enumname)
 
     @debug("begin enum $(enumname)")
-    println(io, "struct __enum_", enumname, " <: ProtoEnum")
-    values = Int32[]
+    println(io, "const ", enumname, " = (;[")
     for value::EnumValueDescriptorProto in enumtype.value
         # If we find that the field name is a keyword prepend it with `_`
         fldname = chk_keyword(value.name)
-        println(io, "    ", fldname, "::Int32")
-        push!(values, value.number)
+        println(io, "    Symbol(\"", fldname, "\") => ", value.number, ",")
     end
-    println(io, "    __enum_", enumname, "() = new(", join(values,','), ")")
-    println(io, "end #struct __enum_", enumname)
-    println(io, "const ", enumname, " = __enum_", enumname, "()")
+    println(io, "]...)")
     println(io, "")
     push!(exports, enumname)
     @debug("end enum $(enumname)")

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -9,8 +9,8 @@ import ProtoBuf: meta, DEF_REQ, DEF_FNUM, DEF_VAL, DEF_PACK
 
 export gen
 
-const JTYPES              = [Float64, Float32, Int64, UInt64, Int32, UInt64,  UInt32,  Bool, AbstractString, Any, Any, Vector{UInt8}, UInt32, Int32, Int32, Int64, Int32, Int64]
-const JTYPE_DEFAULTS      = [0,       0,       0,     0,      0,     0,       0,       false, "",    nothing, nothing, UInt8[], 0,     0,     0,       0,       0,     0]
+const JTYPES              = [Float64, Float32, Int64, UInt64, Int32, UInt64,  UInt32,  Bool,  AbstractString, Any,     Any,     Vector{UInt8}, UInt32, Int32, Int32, Int64, Int32, Int64]
+const JTYPE_DEFAULTS      = [0,       0,       0,     0,      0,     0,       0,       false, "",             nothing, nothing, UInt8[],       0,      0,     0,     0,     0,     0]
 
 isprimitive(fldtype) = (1 <= fldtype <= 8) || (13 <= fldtype <= 18)
 
@@ -241,9 +241,9 @@ function protofile_name_to_module_name(n::String)
 end
 
 function has_gen_services(opt::FileOptions)
-    isfilled(opt, :cc_generic_services) && opt.cc_generic_services && return true
-    isfilled(opt, :py_generic_services) && opt.py_generic_services && return true
-    isfilled(opt, :java_generic_services) && opt.java_generic_services && return true
+    hasproperty(opt, :cc_generic_services) && opt.cc_generic_services && return true
+    hasproperty(opt, :py_generic_services) && opt.py_generic_services && return true
+    hasproperty(opt, :java_generic_services) && opt.java_generic_services && return true
     return false
 end
 
@@ -260,8 +260,7 @@ function append_response(resp::CodeGeneratorResponse, filename::String, io::IOBu
 
     jfile.name = filename
     jfile.content = String(take!(io))
-
-    !isdefined(resp, :file) && (resp.file = CodeGeneratorResponse_File[])
+    !hasproperty(resp, :file) && (resp.file = CodeGeneratorResponse_File[])
     push!(resp.file, jfile)
     resp
 end
@@ -287,7 +286,7 @@ function generate_enum(io::IO, errio::IO, enumtype::EnumDescriptorProto, scope::
     for value::EnumValueDescriptorProto in enumtype.value
         # If we find that the field name is a keyword prepend it with `_`
         fldname = chk_keyword(value.name)
-        println(io, "    Symbol(\"", fldname, "\") => ", value.number, ",")
+        println(io, "    Symbol(\"", fldname, "\") => Int32(", value.number, "),")
     end
     println(io, "]...)")
     println(io, "")
@@ -309,16 +308,16 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
 
     # check oneof
     oneof_names = Vector{String}()
-    if isfilled(dtype, :oneof_decl)
+    if hasproperty(dtype, :oneof_decl)
         for oneof_decl in dtype.oneof_decl
-            if isfilled(oneof_decl, :name)
+            if hasproperty(oneof_decl, :name)
                 push!(oneof_names,  "Symbol(\"$(oneof_decl.name)\")")
             end
         end
     end
 
     # generate enums
-    if isfilled(dtype, :enum_type)
+    if hasproperty(dtype, :enum_type)
         for enum_type in dtype.enum_type
             generate_enum(io, errio, enum_type, scope, exports)
             (errio.size > 0) && return
@@ -326,7 +325,7 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
     end
 
     # generate nested types
-    if isfilled(dtype, :nested_type)
+    if hasproperty(dtype, :nested_type)
         for nested_type::DescriptorProto in dtype.nested_type
             generate_msgtype(io, errio, nested_type, scope, syntax, exports, depends, mapentries, deferedmode)
             (errio.size > 0) && return
@@ -334,22 +333,23 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
     end
 
     # generate this type
-    println(io, "mutable struct $(dtypename) <: ProtoType")
     reqflds = String[]
+    allflds = String[]
+    getpropertylist = Pair[]
     packedflds = String[]
     fldnums = Int[]
     defvals = String[]
     wtypes = String[]
     realfldtypes = String[]
     oneofs = isempty(oneof_names) ? Int[] : zeros(Int, length(dtype.field))
-    ismapentry = isfilled(dtype, :options) && isfilled(dtype.options, :map_entry) && dtype.options.map_entry
+    ismapentry = hasproperty(dtype, :options) && hasproperty(dtype.options, :map_entry) && dtype.options.map_entry
     map_key_type = ""
     map_val_type = ""
 
-    if isfilled(dtype, :field)
+    if hasproperty(dtype, :field)
         for fld_idx in 1:length(dtype.field)
             field = dtype.field[fld_idx]
-            if isfilled(field, :oneof_index) && !isfilled_default(field, :oneof_index)
+            if hasproperty(field, :oneof_index) && !isempty(oneofs)
                 oneof_idx = field.oneof_index + 1
                 oneofs[fld_idx] = oneof_idx
             end
@@ -395,7 +395,7 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
             push!(fldnums, field.number)
             (FieldDescriptorProto_Label.LABEL_REQUIRED == field.label) && push!(reqflds, ":"*fldname)
 
-            if isfilled(field, :default_value) && !isempty(field.default_value)
+            if hasproperty(field, :default_value) && !isempty(field.default_value)
                 if field._type == FieldDescriptorProto_Type.TYPE_STRING
                     push!(defvals, ":$fldname => \"$(escape_string(field.default_value))\"")
                 elseif field._type == FieldDescriptorProto_Type.TYPE_MESSAGE
@@ -417,7 +417,7 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
                 end
             end
 
-            packed = (isfilled(field, :options) && field.options.packed) ||
+            packed = (hasproperty(field, :options) && field.options.packed) ||
                      ((syntax == "proto3") && (FieldDescriptorProto_Label.LABEL_REPEATED == field.label) && isprimitive(field._type))
             packed && push!(packedflds, ":"*fldname)
 
@@ -445,11 +445,13 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
 
             if isempty(gen_typ_name)
                 gen_typ_name = typ_name
+                push!(allflds, ":$fldname => $(typ_name)")
+                push!(getpropertylist, ":$fldname" => "$(typ_name)")
             else
                 push!(realfldtypes, ":$fldname => \"$(typ_name)\"")
+                push!(allflds, ":$fldname => \"$(typ_name)\"")
+                push!(getpropertylist, ":$fldname" => "Any")
             end
-
-            println(io, "    $(fldname)::$gen_typ_name", is_typ_mapentry ? " # map entry" : "")
 
             if ismapentry
                 if field.number == 1
@@ -460,34 +462,73 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
             end
         end
     end
-    println(io, "    $(dtypename)(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)")
-    println(io, "end #mutable struct $(dtypename)", ismapentry ? " (mapentry)" : "", deferedmode ? " (has cyclic type dependency)" : "")
 
-    # generate the meta for this type if required
+    # generate struct body
+    println(io, """mutable struct $(dtypename) <: ProtoType
+        __protobuf_jl_internal_meta::ProtoMeta
+        __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+        function $(dtypename)(; kwargs...)
+            obj = new(meta($(dtypename)), Dict{Symbol,Any}())
+            values = obj.__protobuf_jl_internal_values
+            symdict = obj.__protobuf_jl_internal_meta.symdict
+            for nv in kwargs
+                fldname, fldval = nv
+                fldtype = symdict[fldname].jtyp
+                (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+                values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            end
+            obj
+        end""")
+    println(io, "end # mutable struct $(dtypename)", ismapentry ? " (mapentry)" : "", deferedmode ? " (has cyclic type dependency)" : "")
+
+    # generate the meta for this type
+    @debug("generating meta", dtypename)
     _d_fldnums = [1:length(fldnums);]
-    !isempty(reqflds) && println(io, "const __req_$(dtypename) = Symbol[$(join(reqflds, ','))]")
-    !isempty(defvals) && println(io, "const __val_$(dtypename) = Dict($(join(defvals, ", ")))")
-    (fldnums != _d_fldnums) && println(io, "const __fnum_$(dtypename) = Int[$(join(fldnums, ','))]")
-    !isempty(packedflds) && println(io, "const __pack_$(dtypename) = Symbol[$(join(packedflds, ','))]")
-    !isempty(wtypes) && println(io, "const __wtype_$(dtypename) = Dict($(join(wtypes, ", ")))")
-    !isempty(realfldtypes) && println(io, "const __ftype_$(dtypename) = Dict($(join(realfldtypes, ", ")))")
+    println(io, "const __meta_$(dtypename) = Ref{ProtoMeta}()")
+    println(io, "function meta(::Type{$dtypename})")
+    println(io, "    if !isassigned(__meta_$dtypename)")
+    println(io, "        __meta_$(dtypename)[] = target = ProtoMeta($dtypename)")
+    !isempty(reqflds) && println(io, "        req = Symbol[$(join(reqflds, ','))]")
+    !isempty(defvals) && println(io, "        val = Dict{Symbol,Any}($(join(defvals, ", ")))")
+    (fldnums != _d_fldnums) && println(io, "        fnum = Int[$(join(fldnums, ','))]")
+    !isempty(packedflds) && println(io, "        pack = Symbol[$(join(packedflds, ','))]")
+    !isempty(wtypes) && println(io, "        wtype = Dict($(join(wtypes, ", ")))")
+    println(io, "        allflds = Pair{Symbol,Union{Type,String}}[$(join(allflds, ", "))]")
     if !isempty(oneofs)
-        println(io, "const __oneofs_$(dtypename) = Int[$(join(oneofs, ','))]")
-        println(io, "const __oneof_names_$(dtypename) = [$(join(oneof_names, ','))]")
+        println(io, "        oneofs = Int[$(join(oneofs, ','))]")
+        println(io, "        oneof_names = Symbol[$(join(oneof_names, ','))]")
     end
-    if !isempty(reqflds) || !isempty(defvals) || (fldnums != [1:length(fldnums);]) || !isempty(packedflds) || !isempty(wtypes) || !isempty(oneofs) || !isempty(realfldtypes)
-        @debug("generating meta for type $(dtypename)")
-        print(io, "meta(t::Type{$dtypename}) = meta(t, ")
-        print(io, isempty(reqflds) ? "ProtoBuf.DEF_REQ, " : "__req_$(dtypename), ")
-        print(io, (fldnums == _d_fldnums) ? "ProtoBuf.DEF_FNUM, " : "__fnum_$(dtypename), ")
-        print(io, isempty(defvals) ? "ProtoBuf.DEF_VAL, " : "__val_$(dtypename), ")
-        print(io, "true, ")
-        print(io, isempty(packedflds) ? "ProtoBuf.DEF_PACK, " : "__pack_$(dtypename), ")
-        print(io, isempty(wtypes) ? "ProtoBuf.DEF_WTYPES, " : "__wtype_$(dtypename), ")
-        print(io, isempty(oneofs) ? "ProtoBuf.DEF_ONEOFS, " : "__oneofs_$(dtypename), ")
-        print(io, isempty(oneofs) ? "ProtoBuf.DEF_ONEOF_NAMES, " : "__oneof_names_$(dtypename), ")
-        print(io, isempty(realfldtypes) ? "ProtoBuf.DEF_FIELD_TYPES" : "__ftype_$(dtypename)")
-        println(io, ")")
+
+    print(io, "        meta(target, $(dtypename), allflds, ")
+    print(io, isempty(reqflds) ? "ProtoBuf.DEF_REQ, " : "req, ")
+    print(io, (fldnums == _d_fldnums) ? "ProtoBuf.DEF_FNUM, " : "fnum, ")
+    print(io, isempty(defvals) ? "ProtoBuf.DEF_VAL, " : "val, ")
+    print(io, isempty(packedflds) ? "ProtoBuf.DEF_PACK, " : "pack, ")
+    print(io, isempty(wtypes) ? "ProtoBuf.DEF_WTYPES, " : "wtype, ")
+    print(io, isempty(oneofs) ? "ProtoBuf.DEF_ONEOFS, " : "oneofs, ")
+    print(io, isempty(oneofs) ? "ProtoBuf.DEF_ONEOF_NAMES" : "oneof_names")
+    println(io, ")")
+    println(io, "    end")
+    println(io, "    __meta_$(dtypename)[]")
+    println(io, "end")
+
+    # generate new getproperty method
+    if !isempty(getpropertylist)
+        @debug("generating getproperty", dtypename)
+        println(io, "function Base.getproperty(obj::$(dtypename), name::Symbol)")
+        pfx = "if"
+        for prop in getpropertylist
+            println(io, "    $(pfx) name === $(first(prop))")
+            println(io, "        return (obj.__protobuf_jl_internal_values[name])::$(last(prop))")
+            if pfx == "if"
+                pfx = "elseif"
+            end
+        end
+        println(io, "    else")
+        println(io, "        getfield(obj, name)")
+        println(io, "    end")
+        println(io, "end")
     end
 
     println(io, "")
@@ -497,18 +538,18 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
     deferedmode && (full_dtypename in keys(_deferred)) && delete!(_deferred, full_dtypename)
 
     if !isdeferred(full_dtypename)
-        @debug("resolved (!deferred) $full_dtypename")
+        @debug("resolved (!deferred)", full_dtypename)
         print(outio, String(take!(io)))
         deferedmode || resolve(outio, full_dtypename)
         push!(_all_resolved, full_dtypename)
     end
 
-    @debug("end type $(full_dtypename)")
+    @debug("end type", full_dtypename)
     nothing
 end
 
 function generate_svc(io::IO, errio::IO, stype::ServiceDescriptorProto, scope::Scope, svcidx::Int, exports::Vector{String})
-    nmethods = isfilled(stype, :method) ? length(stype.method) : 0
+    nmethods = hasproperty(stype, :method) ? length(stype.method) : 0
 
     # generate method and service descriptors
     println(io, "# service methods for $(stype.name)")
@@ -566,7 +607,7 @@ end
 function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
     @debug("generate begin for $(protofile.name), package $(protofile.package)")
 
-    svcs = isfilled(protofile, :options) ? has_gen_services(protofile.options) : false
+    svcs = hasproperty(protofile, :options) ? has_gen_services(protofile.options) : false
     @debug("generate services: $svcs")
 
     scope = top_scope
@@ -586,7 +627,7 @@ function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
     end
 
     # generate syntax version
-    syntax = (isfilled(protofile, :syntax) && !isempty(protofile.syntax)) ? protofile.syntax : "proto2"
+    syntax = (hasproperty(protofile, :syntax) && !isempty(protofile.syntax)) ? protofile.syntax : "proto2"
     println(io, "# syntax: $(syntax)")
 
     depends = Vector{String}()
@@ -599,7 +640,7 @@ function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
         nothing
     end
     add_import("ProtoBuf.meta")
-    if isfilled(protofile, :dependency)
+    if hasproperty(protofile, :dependency)
         protofile_imports[protofile.name] = protofile.dependency
         using_pkgs = Set{String}()
         for dependency in protofile.dependency
@@ -642,7 +683,7 @@ function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
 
     # generate top level enums
     @debug("generating enums")
-    if isfilled(protofile, :enum_type)
+    if hasproperty(protofile, :enum_type)
         for enum_type in protofile.enum_type
             generate_enum(io, errio, enum_type, scope, exports)
             (errio.size > 0) && return
@@ -651,7 +692,7 @@ function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
 
     # generate message types
     @debug("generating types")
-    if isfilled(protofile, :message_type)
+    if hasproperty(protofile, :message_type)
         for message_type in protofile.message_type
             generate_msgtype(io, errio, message_type, scope, syntax, exports, depends, mapentries, false)
             (errio.size > 0) && return
@@ -660,7 +701,7 @@ function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
 
     # generate service stubs
     @debug("generating services")
-    if svcs && isfilled(protofile, :service)
+    if svcs && hasproperty(protofile, :service)
         nservices = length(protofile.service)
         for idx in 1:nservices
             service = protofile.service[idx]
@@ -671,7 +712,7 @@ function generate_file(io::IO, errio::IO, protofile::FileDescriptorProto)
 
     # generate deferred message types
     @debug("generating deferred types")
-    if isfilled(protofile, :message_type)
+    if hasproperty(protofile, :message_type)
         for message_type in protofile.message_type
             generate_msgtype(io, errio, message_type, scope, syntax, exports, depends, mapentries, true)
             (errio.size > 0) && return
@@ -740,7 +781,7 @@ function codegen(srcio::IO)
     while !eof(srcio)
         req = readreq(srcio)
 
-        if !isfilled(req, :file_to_generate)
+        if !hasproperty(req, :file_to_generate)
             @debug("no files to generate!!")
             continue
         end
@@ -748,7 +789,7 @@ function codegen(srcio::IO)
         @debug("generate request for $(length(req.file_to_generate)) proto files")
         @debug("$(req.file_to_generate)")
 
-        #isfilled(req, :parameter) && @debug("parameter $(req.parameter)")
+        #hasproperty(req, :parameter) && @debug("parameter $(req.parameter)")
 
         for protofile in req.proto_file
             io = IOBuffer()

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -1,8 +1,8 @@
 module Gen
 
-using ProtoBuf
-using ProtoBuf.GoogleProtoBuf
-using ProtoBuf.GoogleProtoBufCompiler
+using ..ProtoBuf
+using ..ProtoBuf.GoogleProtoBuf
+using ..ProtoBuf.GoogleProtoBufCompiler
 using Logging
 
 import ProtoBuf: meta, DEF_REQ, DEF_FNUM, DEF_VAL, DEF_PACK

--- a/src/google/any_pb.jl
+++ b/src/google/any_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct _Any <: ProtoType
     type_url::AbstractString
     value::Array{UInt8,1}

--- a/src/google/any_pb.jl
+++ b/src/google/any_pb.jl
@@ -1,8 +1,38 @@
 # syntax: proto3
 mutable struct _Any <: ProtoType
-    type_url::AbstractString
-    value::Array{UInt8,1}
-    _Any(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct _Any
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function _Any(; kwargs...)
+        obj = new(meta(_Any), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct _Any
+const __meta__Any = Ref{ProtoMeta}()
+function meta(::Type{_Any})
+    if !isassigned(__meta__Any)
+        __meta__Any[] = target = ProtoMeta(_Any)
+        allflds = Pair{Symbol,Union{Type,String}}[:type_url => AbstractString, :value => Array{UInt8,1}]
+        meta(target, _Any, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta__Any[]
+end
+function Base.getproperty(obj::_Any, name::Symbol)
+    if name === :type_url
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Array{UInt8,1}
+    else
+        getfield(obj, name)
+    end
+end
 
 export _Any

--- a/src/google/any_pb.jl
+++ b/src/google/any_pb.jl
@@ -18,12 +18,14 @@ mutable struct _Any <: ProtoType
 end # mutable struct _Any
 const __meta__Any = Ref{ProtoMeta}()
 function meta(::Type{_Any})
-    if !isassigned(__meta__Any)
-        __meta__Any[] = target = ProtoMeta(_Any)
-        allflds = Pair{Symbol,Union{Type,String}}[:type_url => AbstractString, :value => Array{UInt8,1}]
-        meta(target, _Any, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta__Any)
+            __meta__Any[] = target = ProtoMeta(_Any)
+            allflds = Pair{Symbol,Union{Type,String}}[:type_url => AbstractString, :value => Array{UInt8,1}]
+            meta(target, _Any, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta__Any[]
     end
-    __meta__Any[]
 end
 function Base.getproperty(obj::_Any, name::Symbol)
     if name === :type_url

--- a/src/google/api_pb.jl
+++ b/src/google/api_pb.jl
@@ -18,12 +18,14 @@ mutable struct Method <: ProtoType
 end # mutable struct Method
 const __meta_Method = Ref{ProtoMeta}()
 function meta(::Type{Method})
-    if !isassigned(__meta_Method)
-        __meta_Method[] = target = ProtoMeta(Method)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :request_type_url => AbstractString, :request_streaming => Bool, :response_type_url => AbstractString, :response_streaming => Bool, :options => Base.Vector{Option}, :syntax => Int32]
-        meta(target, Method, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Method)
+            __meta_Method[] = target = ProtoMeta(Method)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :request_type_url => AbstractString, :request_streaming => Bool, :response_type_url => AbstractString, :response_streaming => Bool, :options => Base.Vector{Option}, :syntax => Int32]
+            meta(target, Method, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Method[]
     end
-    __meta_Method[]
 end
 function Base.getproperty(obj::Method, name::Symbol)
     if name === :name
@@ -64,12 +66,14 @@ mutable struct Mixin <: ProtoType
 end # mutable struct Mixin
 const __meta_Mixin = Ref{ProtoMeta}()
 function meta(::Type{Mixin})
-    if !isassigned(__meta_Mixin)
-        __meta_Mixin[] = target = ProtoMeta(Mixin)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :root => AbstractString]
-        meta(target, Mixin, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Mixin)
+            __meta_Mixin[] = target = ProtoMeta(Mixin)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :root => AbstractString]
+            meta(target, Mixin, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Mixin[]
     end
-    __meta_Mixin[]
 end
 function Base.getproperty(obj::Mixin, name::Symbol)
     if name === :name
@@ -100,12 +104,14 @@ mutable struct Api <: ProtoType
 end # mutable struct Api
 const __meta_Api = Ref{ProtoMeta}()
 function meta(::Type{Api})
-    if !isassigned(__meta_Api)
-        __meta_Api[] = target = ProtoMeta(Api)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :methods => Base.Vector{Method}, :options => Base.Vector{Option}, :version => AbstractString, :source_context => SourceContext, :mixins => Base.Vector{Mixin}, :syntax => Int32]
-        meta(target, Api, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Api)
+            __meta_Api[] = target = ProtoMeta(Api)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :methods => Base.Vector{Method}, :options => Base.Vector{Option}, :version => AbstractString, :source_context => SourceContext, :mixins => Base.Vector{Mixin}, :syntax => Int32]
+            meta(target, Api, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Api[]
     end
-    __meta_Api[]
 end
 function Base.getproperty(obj::Api, name::Symbol)
     if name === :name

--- a/src/google/api_pb.jl
+++ b/src/google/api_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct Method <: ProtoType
     name::AbstractString
     request_type_url::AbstractString

--- a/src/google/api_pb.jl
+++ b/src/google/api_pb.jl
@@ -1,30 +1,130 @@
 # syntax: proto3
 mutable struct Method <: ProtoType
-    name::AbstractString
-    request_type_url::AbstractString
-    request_streaming::Bool
-    response_type_url::AbstractString
-    response_streaming::Bool
-    options::Base.Vector{Option}
-    syntax::Int32
-    Method(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Method
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Method(; kwargs...)
+        obj = new(meta(Method), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Method
+const __meta_Method = Ref{ProtoMeta}()
+function meta(::Type{Method})
+    if !isassigned(__meta_Method)
+        __meta_Method[] = target = ProtoMeta(Method)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :request_type_url => AbstractString, :request_streaming => Bool, :response_type_url => AbstractString, :response_streaming => Bool, :options => Base.Vector{Option}, :syntax => Int32]
+        meta(target, Method, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Method[]
+end
+function Base.getproperty(obj::Method, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :request_type_url
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :request_streaming
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :response_type_url
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :response_streaming
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Option}
+    elseif name === :syntax
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct Mixin <: ProtoType
-    name::AbstractString
-    root::AbstractString
-    Mixin(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Mixin
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Mixin(; kwargs...)
+        obj = new(meta(Mixin), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Mixin
+const __meta_Mixin = Ref{ProtoMeta}()
+function meta(::Type{Mixin})
+    if !isassigned(__meta_Mixin)
+        __meta_Mixin[] = target = ProtoMeta(Mixin)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :root => AbstractString]
+        meta(target, Mixin, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Mixin[]
+end
+function Base.getproperty(obj::Mixin, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :root
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct Api <: ProtoType
-    name::AbstractString
-    methods::Base.Vector{Method}
-    options::Base.Vector{Option}
-    version::AbstractString
-    source_context::SourceContext
-    mixins::Base.Vector{Mixin}
-    syntax::Int32
-    Api(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Api
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Api(; kwargs...)
+        obj = new(meta(Api), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Api
+const __meta_Api = Ref{ProtoMeta}()
+function meta(::Type{Api})
+    if !isassigned(__meta_Api)
+        __meta_Api[] = target = ProtoMeta(Api)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :methods => Base.Vector{Method}, :options => Base.Vector{Option}, :version => AbstractString, :source_context => SourceContext, :mixins => Base.Vector{Mixin}, :syntax => Int32]
+        meta(target, Api, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Api[]
+end
+function Base.getproperty(obj::Api, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :methods
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Method}
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Option}
+    elseif name === :version
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :source_context
+        return (obj.__protobuf_jl_internal_values[name])::SourceContext
+    elseif name === :mixins
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Mixin}
+    elseif name === :syntax
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 export Api, Method, Mixin

--- a/src/google/descriptor_pb.jl
+++ b/src/google/descriptor_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto2
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct UninterpretedOption_NamePart <: ProtoType
     name_part::AbstractString
     is_extension::Bool

--- a/src/google/descriptor_pb.jl
+++ b/src/google/descriptor_pb.jl
@@ -18,13 +18,15 @@ mutable struct UninterpretedOption_NamePart <: ProtoType
 end # mutable struct UninterpretedOption_NamePart
 const __meta_UninterpretedOption_NamePart = Ref{ProtoMeta}()
 function meta(::Type{UninterpretedOption_NamePart})
-    if !isassigned(__meta_UninterpretedOption_NamePart)
-        __meta_UninterpretedOption_NamePart[] = target = ProtoMeta(UninterpretedOption_NamePart)
-        req = Symbol[:name_part,:is_extension]
-        allflds = Pair{Symbol,Union{Type,String}}[:name_part => AbstractString, :is_extension => Bool]
-        meta(target, UninterpretedOption_NamePart, allflds, req, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_UninterpretedOption_NamePart)
+            __meta_UninterpretedOption_NamePart[] = target = ProtoMeta(UninterpretedOption_NamePart)
+            req = Symbol[:name_part,:is_extension]
+            allflds = Pair{Symbol,Union{Type,String}}[:name_part => AbstractString, :is_extension => Bool]
+            meta(target, UninterpretedOption_NamePart, allflds, req, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_UninterpretedOption_NamePart[]
     end
-    __meta_UninterpretedOption_NamePart[]
 end
 function Base.getproperty(obj::UninterpretedOption_NamePart, name::Symbol)
     if name === :name_part
@@ -55,13 +57,15 @@ mutable struct UninterpretedOption <: ProtoType
 end # mutable struct UninterpretedOption
 const __meta_UninterpretedOption = Ref{ProtoMeta}()
 function meta(::Type{UninterpretedOption})
-    if !isassigned(__meta_UninterpretedOption)
-        __meta_UninterpretedOption[] = target = ProtoMeta(UninterpretedOption)
-        fnum = Int[2,3,4,5,6,7,8]
-        allflds = Pair{Symbol,Union{Type,String}}[:name => Base.Vector{UninterpretedOption_NamePart}, :identifier_value => AbstractString, :positive_int_value => UInt64, :negative_int_value => Int64, :double_value => Float64, :string_value => Array{UInt8,1}, :aggregate_value => AbstractString]
-        meta(target, UninterpretedOption, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_UninterpretedOption)
+            __meta_UninterpretedOption[] = target = ProtoMeta(UninterpretedOption)
+            fnum = Int[2,3,4,5,6,7,8]
+            allflds = Pair{Symbol,Union{Type,String}}[:name => Base.Vector{UninterpretedOption_NamePart}, :identifier_value => AbstractString, :positive_int_value => UInt64, :negative_int_value => Int64, :double_value => Float64, :string_value => Array{UInt8,1}, :aggregate_value => AbstractString]
+            meta(target, UninterpretedOption, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_UninterpretedOption[]
     end
-    __meta_UninterpretedOption[]
 end
 function Base.getproperty(obj::UninterpretedOption, name::Symbol)
     if name === :name
@@ -114,14 +118,16 @@ mutable struct FieldOptions <: ProtoType
 end # mutable struct FieldOptions
 const __meta_FieldOptions = Ref{ProtoMeta}()
 function meta(::Type{FieldOptions})
-    if !isassigned(__meta_FieldOptions)
-        __meta_FieldOptions[] = target = ProtoMeta(FieldOptions)
-        val = Dict{Symbol,Any}(:ctype => FieldOptions_CType.STRING, :jstype => FieldOptions_JSType.JS_NORMAL, :lazy => false, :deprecated => false, :weak => false)
-        fnum = Int[1,2,6,5,3,10,999]
-        allflds = Pair{Symbol,Union{Type,String}}[:ctype => Int32, :packed => Bool, :jstype => Int32, :lazy => Bool, :deprecated => Bool, :weak => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, FieldOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_FieldOptions)
+            __meta_FieldOptions[] = target = ProtoMeta(FieldOptions)
+            val = Dict{Symbol,Any}(:ctype => FieldOptions_CType.STRING, :jstype => FieldOptions_JSType.JS_NORMAL, :lazy => false, :deprecated => false, :weak => false)
+            fnum = Int[1,2,6,5,3,10,999]
+            allflds = Pair{Symbol,Union{Type,String}}[:ctype => Int32, :packed => Bool, :jstype => Int32, :lazy => Bool, :deprecated => Bool, :weak => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, FieldOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_FieldOptions[]
     end
-    __meta_FieldOptions[]
 end
 function Base.getproperty(obj::FieldOptions, name::Symbol)
     if name === :ctype
@@ -162,14 +168,16 @@ mutable struct MessageOptions <: ProtoType
 end # mutable struct MessageOptions
 const __meta_MessageOptions = Ref{ProtoMeta}()
 function meta(::Type{MessageOptions})
-    if !isassigned(__meta_MessageOptions)
-        __meta_MessageOptions[] = target = ProtoMeta(MessageOptions)
-        val = Dict{Symbol,Any}(:message_set_wire_format => false, :no_standard_descriptor_accessor => false, :deprecated => false)
-        fnum = Int[1,2,3,7,999]
-        allflds = Pair{Symbol,Union{Type,String}}[:message_set_wire_format => Bool, :no_standard_descriptor_accessor => Bool, :deprecated => Bool, :map_entry => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, MessageOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_MessageOptions)
+            __meta_MessageOptions[] = target = ProtoMeta(MessageOptions)
+            val = Dict{Symbol,Any}(:message_set_wire_format => false, :no_standard_descriptor_accessor => false, :deprecated => false)
+            fnum = Int[1,2,3,7,999]
+            allflds = Pair{Symbol,Union{Type,String}}[:message_set_wire_format => Bool, :no_standard_descriptor_accessor => Bool, :deprecated => Bool, :map_entry => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, MessageOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_MessageOptions[]
     end
-    __meta_MessageOptions[]
 end
 function Base.getproperty(obj::MessageOptions, name::Symbol)
     if name === :message_set_wire_format
@@ -206,14 +214,16 @@ mutable struct EnumOptions <: ProtoType
 end # mutable struct EnumOptions
 const __meta_EnumOptions = Ref{ProtoMeta}()
 function meta(::Type{EnumOptions})
-    if !isassigned(__meta_EnumOptions)
-        __meta_EnumOptions[] = target = ProtoMeta(EnumOptions)
-        val = Dict{Symbol,Any}(:deprecated => false)
-        fnum = Int[2,3,999]
-        allflds = Pair{Symbol,Union{Type,String}}[:allow_alias => Bool, :deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, EnumOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_EnumOptions)
+            __meta_EnumOptions[] = target = ProtoMeta(EnumOptions)
+            val = Dict{Symbol,Any}(:deprecated => false)
+            fnum = Int[2,3,999]
+            allflds = Pair{Symbol,Union{Type,String}}[:allow_alias => Bool, :deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, EnumOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_EnumOptions[]
     end
-    __meta_EnumOptions[]
 end
 function Base.getproperty(obj::EnumOptions, name::Symbol)
     if name === :allow_alias
@@ -246,13 +256,15 @@ mutable struct ExtensionRangeOptions <: ProtoType
 end # mutable struct ExtensionRangeOptions
 const __meta_ExtensionRangeOptions = Ref{ProtoMeta}()
 function meta(::Type{ExtensionRangeOptions})
-    if !isassigned(__meta_ExtensionRangeOptions)
-        __meta_ExtensionRangeOptions[] = target = ProtoMeta(ExtensionRangeOptions)
-        fnum = Int[999]
-        allflds = Pair{Symbol,Union{Type,String}}[:uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, ExtensionRangeOptions, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_ExtensionRangeOptions)
+            __meta_ExtensionRangeOptions[] = target = ProtoMeta(ExtensionRangeOptions)
+            fnum = Int[999]
+            allflds = Pair{Symbol,Union{Type,String}}[:uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, ExtensionRangeOptions, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_ExtensionRangeOptions[]
     end
-    __meta_ExtensionRangeOptions[]
 end
 function Base.getproperty(obj::ExtensionRangeOptions, name::Symbol)
     if name === :uninterpreted_option
@@ -287,14 +299,16 @@ mutable struct MethodOptions <: ProtoType
 end # mutable struct MethodOptions
 const __meta_MethodOptions = Ref{ProtoMeta}()
 function meta(::Type{MethodOptions})
-    if !isassigned(__meta_MethodOptions)
-        __meta_MethodOptions[] = target = ProtoMeta(MethodOptions)
-        val = Dict{Symbol,Any}(:deprecated => false, :idempotency_level => MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN)
-        fnum = Int[33,34,999]
-        allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :idempotency_level => Int32, :uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, MethodOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_MethodOptions)
+            __meta_MethodOptions[] = target = ProtoMeta(MethodOptions)
+            val = Dict{Symbol,Any}(:deprecated => false, :idempotency_level => MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN)
+            fnum = Int[33,34,999]
+            allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :idempotency_level => Int32, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, MethodOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_MethodOptions[]
     end
-    __meta_MethodOptions[]
 end
 function Base.getproperty(obj::MethodOptions, name::Symbol)
     if name === :deprecated
@@ -333,14 +347,16 @@ mutable struct FileOptions <: ProtoType
 end # mutable struct FileOptions
 const __meta_FileOptions = Ref{ProtoMeta}()
 function meta(::Type{FileOptions})
-    if !isassigned(__meta_FileOptions)
-        __meta_FileOptions[] = target = ProtoMeta(FileOptions)
-        val = Dict{Symbol,Any}(:java_multiple_files => false, :java_string_check_utf8 => false, :optimize_for => FileOptions_OptimizeMode.SPEED, :cc_generic_services => false, :java_generic_services => false, :py_generic_services => false, :php_generic_services => false, :deprecated => false, :cc_enable_arenas => false)
-        fnum = Int[1,8,10,20,27,9,11,16,17,18,42,23,31,36,37,39,40,41,44,45,999]
-        allflds = Pair{Symbol,Union{Type,String}}[:java_package => AbstractString, :java_outer_classname => AbstractString, :java_multiple_files => Bool, :java_generate_equals_and_hash => Bool, :java_string_check_utf8 => Bool, :optimize_for => Int32, :go_package => AbstractString, :cc_generic_services => Bool, :java_generic_services => Bool, :py_generic_services => Bool, :php_generic_services => Bool, :deprecated => Bool, :cc_enable_arenas => Bool, :objc_class_prefix => AbstractString, :csharp_namespace => AbstractString, :swift_prefix => AbstractString, :php_class_prefix => AbstractString, :php_namespace => AbstractString, :php_metadata_namespace => AbstractString, :ruby_package => AbstractString, :uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, FileOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_FileOptions)
+            __meta_FileOptions[] = target = ProtoMeta(FileOptions)
+            val = Dict{Symbol,Any}(:java_multiple_files => false, :java_string_check_utf8 => false, :optimize_for => FileOptions_OptimizeMode.SPEED, :cc_generic_services => false, :java_generic_services => false, :py_generic_services => false, :php_generic_services => false, :deprecated => false, :cc_enable_arenas => false)
+            fnum = Int[1,8,10,20,27,9,11,16,17,18,42,23,31,36,37,39,40,41,44,45,999]
+            allflds = Pair{Symbol,Union{Type,String}}[:java_package => AbstractString, :java_outer_classname => AbstractString, :java_multiple_files => Bool, :java_generate_equals_and_hash => Bool, :java_string_check_utf8 => Bool, :optimize_for => Int32, :go_package => AbstractString, :cc_generic_services => Bool, :java_generic_services => Bool, :py_generic_services => Bool, :php_generic_services => Bool, :deprecated => Bool, :cc_enable_arenas => Bool, :objc_class_prefix => AbstractString, :csharp_namespace => AbstractString, :swift_prefix => AbstractString, :php_class_prefix => AbstractString, :php_namespace => AbstractString, :php_metadata_namespace => AbstractString, :ruby_package => AbstractString, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, FileOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_FileOptions[]
     end
-    __meta_FileOptions[]
 end
 function Base.getproperty(obj::FileOptions, name::Symbol)
     if name === :java_package
@@ -409,14 +425,16 @@ mutable struct EnumValueOptions <: ProtoType
 end # mutable struct EnumValueOptions
 const __meta_EnumValueOptions = Ref{ProtoMeta}()
 function meta(::Type{EnumValueOptions})
-    if !isassigned(__meta_EnumValueOptions)
-        __meta_EnumValueOptions[] = target = ProtoMeta(EnumValueOptions)
-        val = Dict{Symbol,Any}(:deprecated => false)
-        fnum = Int[1,999]
-        allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, EnumValueOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_EnumValueOptions)
+            __meta_EnumValueOptions[] = target = ProtoMeta(EnumValueOptions)
+            val = Dict{Symbol,Any}(:deprecated => false)
+            fnum = Int[1,999]
+            allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, EnumValueOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_EnumValueOptions[]
     end
-    __meta_EnumValueOptions[]
 end
 function Base.getproperty(obj::EnumValueOptions, name::Symbol)
     if name === :deprecated
@@ -447,13 +465,15 @@ mutable struct OneofOptions <: ProtoType
 end # mutable struct OneofOptions
 const __meta_OneofOptions = Ref{ProtoMeta}()
 function meta(::Type{OneofOptions})
-    if !isassigned(__meta_OneofOptions)
-        __meta_OneofOptions[] = target = ProtoMeta(OneofOptions)
-        fnum = Int[999]
-        allflds = Pair{Symbol,Union{Type,String}}[:uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, OneofOptions, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_OneofOptions)
+            __meta_OneofOptions[] = target = ProtoMeta(OneofOptions)
+            fnum = Int[999]
+            allflds = Pair{Symbol,Union{Type,String}}[:uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, OneofOptions, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_OneofOptions[]
     end
-    __meta_OneofOptions[]
 end
 function Base.getproperty(obj::OneofOptions, name::Symbol)
     if name === :uninterpreted_option
@@ -482,14 +502,16 @@ mutable struct ServiceOptions <: ProtoType
 end # mutable struct ServiceOptions
 const __meta_ServiceOptions = Ref{ProtoMeta}()
 function meta(::Type{ServiceOptions})
-    if !isassigned(__meta_ServiceOptions)
-        __meta_ServiceOptions[] = target = ProtoMeta(ServiceOptions)
-        val = Dict{Symbol,Any}(:deprecated => false)
-        fnum = Int[33,999]
-        allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
-        meta(target, ServiceOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_ServiceOptions)
+            __meta_ServiceOptions[] = target = ProtoMeta(ServiceOptions)
+            val = Dict{Symbol,Any}(:deprecated => false)
+            fnum = Int[33,999]
+            allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+            meta(target, ServiceOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_ServiceOptions[]
     end
-    __meta_ServiceOptions[]
 end
 function Base.getproperty(obj::ServiceOptions, name::Symbol)
     if name === :deprecated
@@ -547,13 +569,15 @@ mutable struct FieldDescriptorProto <: ProtoType
 end # mutable struct FieldDescriptorProto
 const __meta_FieldDescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{FieldDescriptorProto})
-    if !isassigned(__meta_FieldDescriptorProto)
-        __meta_FieldDescriptorProto[] = target = ProtoMeta(FieldDescriptorProto)
-        fnum = Int[1,3,4,5,6,2,7,9,10,8]
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :label => Int32, :_type => Int32, :type_name => AbstractString, :extendee => AbstractString, :default_value => AbstractString, :oneof_index => Int32, :json_name => AbstractString, :options => FieldOptions]
-        meta(target, FieldDescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_FieldDescriptorProto)
+            __meta_FieldDescriptorProto[] = target = ProtoMeta(FieldDescriptorProto)
+            fnum = Int[1,3,4,5,6,2,7,9,10,8]
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :label => Int32, :_type => Int32, :type_name => AbstractString, :extendee => AbstractString, :default_value => AbstractString, :oneof_index => Int32, :json_name => AbstractString, :options => FieldOptions]
+            meta(target, FieldDescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_FieldDescriptorProto[]
     end
-    __meta_FieldDescriptorProto[]
 end
 function Base.getproperty(obj::FieldDescriptorProto, name::Symbol)
     if name === :name
@@ -600,12 +624,14 @@ mutable struct DescriptorProto_ExtensionRange <: ProtoType
 end # mutable struct DescriptorProto_ExtensionRange
 const __meta_DescriptorProto_ExtensionRange = Ref{ProtoMeta}()
 function meta(::Type{DescriptorProto_ExtensionRange})
-    if !isassigned(__meta_DescriptorProto_ExtensionRange)
-        __meta_DescriptorProto_ExtensionRange[] = target = ProtoMeta(DescriptorProto_ExtensionRange)
-        allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32, :options => ExtensionRangeOptions]
-        meta(target, DescriptorProto_ExtensionRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_DescriptorProto_ExtensionRange)
+            __meta_DescriptorProto_ExtensionRange[] = target = ProtoMeta(DescriptorProto_ExtensionRange)
+            allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32, :options => ExtensionRangeOptions]
+            meta(target, DescriptorProto_ExtensionRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_DescriptorProto_ExtensionRange[]
     end
-    __meta_DescriptorProto_ExtensionRange[]
 end
 function Base.getproperty(obj::DescriptorProto_ExtensionRange, name::Symbol)
     if name === :start
@@ -638,13 +664,15 @@ mutable struct MethodDescriptorProto <: ProtoType
 end # mutable struct MethodDescriptorProto
 const __meta_MethodDescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{MethodDescriptorProto})
-    if !isassigned(__meta_MethodDescriptorProto)
-        __meta_MethodDescriptorProto[] = target = ProtoMeta(MethodDescriptorProto)
-        val = Dict{Symbol,Any}(:client_streaming => false, :server_streaming => false)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :input_type => AbstractString, :output_type => AbstractString, :options => MethodOptions, :client_streaming => Bool, :server_streaming => Bool]
-        meta(target, MethodDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_MethodDescriptorProto)
+            __meta_MethodDescriptorProto[] = target = ProtoMeta(MethodDescriptorProto)
+            val = Dict{Symbol,Any}(:client_streaming => false, :server_streaming => false)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :input_type => AbstractString, :output_type => AbstractString, :options => MethodOptions, :client_streaming => Bool, :server_streaming => Bool]
+            meta(target, MethodDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_MethodDescriptorProto[]
     end
-    __meta_MethodDescriptorProto[]
 end
 function Base.getproperty(obj::MethodDescriptorProto, name::Symbol)
     if name === :name
@@ -683,12 +711,14 @@ mutable struct EnumValueDescriptorProto <: ProtoType
 end # mutable struct EnumValueDescriptorProto
 const __meta_EnumValueDescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{EnumValueDescriptorProto})
-    if !isassigned(__meta_EnumValueDescriptorProto)
-        __meta_EnumValueDescriptorProto[] = target = ProtoMeta(EnumValueDescriptorProto)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :options => EnumValueOptions]
-        meta(target, EnumValueDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_EnumValueDescriptorProto)
+            __meta_EnumValueDescriptorProto[] = target = ProtoMeta(EnumValueDescriptorProto)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :options => EnumValueOptions]
+            meta(target, EnumValueDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_EnumValueDescriptorProto[]
     end
-    __meta_EnumValueDescriptorProto[]
 end
 function Base.getproperty(obj::EnumValueDescriptorProto, name::Symbol)
     if name === :name
@@ -721,12 +751,14 @@ mutable struct EnumDescriptorProto_EnumReservedRange <: ProtoType
 end # mutable struct EnumDescriptorProto_EnumReservedRange
 const __meta_EnumDescriptorProto_EnumReservedRange = Ref{ProtoMeta}()
 function meta(::Type{EnumDescriptorProto_EnumReservedRange})
-    if !isassigned(__meta_EnumDescriptorProto_EnumReservedRange)
-        __meta_EnumDescriptorProto_EnumReservedRange[] = target = ProtoMeta(EnumDescriptorProto_EnumReservedRange)
-        allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32]
-        meta(target, EnumDescriptorProto_EnumReservedRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_EnumDescriptorProto_EnumReservedRange)
+            __meta_EnumDescriptorProto_EnumReservedRange[] = target = ProtoMeta(EnumDescriptorProto_EnumReservedRange)
+            allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32]
+            meta(target, EnumDescriptorProto_EnumReservedRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_EnumDescriptorProto_EnumReservedRange[]
     end
-    __meta_EnumDescriptorProto_EnumReservedRange[]
 end
 function Base.getproperty(obj::EnumDescriptorProto_EnumReservedRange, name::Symbol)
     if name === :start
@@ -757,12 +789,14 @@ mutable struct EnumDescriptorProto <: ProtoType
 end # mutable struct EnumDescriptorProto
 const __meta_EnumDescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{EnumDescriptorProto})
-    if !isassigned(__meta_EnumDescriptorProto)
-        __meta_EnumDescriptorProto[] = target = ProtoMeta(EnumDescriptorProto)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :value => Base.Vector{EnumValueDescriptorProto}, :options => EnumOptions, :reserved_range => Base.Vector{EnumDescriptorProto_EnumReservedRange}, :reserved_name => Base.Vector{AbstractString}]
-        meta(target, EnumDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_EnumDescriptorProto)
+            __meta_EnumDescriptorProto[] = target = ProtoMeta(EnumDescriptorProto)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :value => Base.Vector{EnumValueDescriptorProto}, :options => EnumOptions, :reserved_range => Base.Vector{EnumDescriptorProto_EnumReservedRange}, :reserved_name => Base.Vector{AbstractString}]
+            meta(target, EnumDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_EnumDescriptorProto[]
     end
-    __meta_EnumDescriptorProto[]
 end
 function Base.getproperty(obj::EnumDescriptorProto, name::Symbol)
     if name === :name
@@ -799,12 +833,14 @@ mutable struct OneofDescriptorProto <: ProtoType
 end # mutable struct OneofDescriptorProto
 const __meta_OneofDescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{OneofDescriptorProto})
-    if !isassigned(__meta_OneofDescriptorProto)
-        __meta_OneofDescriptorProto[] = target = ProtoMeta(OneofDescriptorProto)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :options => OneofOptions]
-        meta(target, OneofDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_OneofDescriptorProto)
+            __meta_OneofDescriptorProto[] = target = ProtoMeta(OneofDescriptorProto)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :options => OneofOptions]
+            meta(target, OneofDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_OneofDescriptorProto[]
     end
-    __meta_OneofDescriptorProto[]
 end
 function Base.getproperty(obj::OneofDescriptorProto, name::Symbol)
     if name === :name
@@ -835,12 +871,14 @@ mutable struct DescriptorProto_ReservedRange <: ProtoType
 end # mutable struct DescriptorProto_ReservedRange
 const __meta_DescriptorProto_ReservedRange = Ref{ProtoMeta}()
 function meta(::Type{DescriptorProto_ReservedRange})
-    if !isassigned(__meta_DescriptorProto_ReservedRange)
-        __meta_DescriptorProto_ReservedRange[] = target = ProtoMeta(DescriptorProto_ReservedRange)
-        allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32]
-        meta(target, DescriptorProto_ReservedRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_DescriptorProto_ReservedRange)
+            __meta_DescriptorProto_ReservedRange[] = target = ProtoMeta(DescriptorProto_ReservedRange)
+            allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32]
+            meta(target, DescriptorProto_ReservedRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_DescriptorProto_ReservedRange[]
     end
-    __meta_DescriptorProto_ReservedRange[]
 end
 function Base.getproperty(obj::DescriptorProto_ReservedRange, name::Symbol)
     if name === :start
@@ -871,13 +909,15 @@ mutable struct DescriptorProto <: ProtoType
 end # mutable struct DescriptorProto
 const __meta_DescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{DescriptorProto})
-    if !isassigned(__meta_DescriptorProto)
-        __meta_DescriptorProto[] = target = ProtoMeta(DescriptorProto)
-        fnum = Int[1,2,6,3,4,5,8,7,9,10]
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :field => Base.Vector{FieldDescriptorProto}, :extension => Base.Vector{FieldDescriptorProto}, :nested_type => Base.Vector{DescriptorProto}, :enum_type => Base.Vector{EnumDescriptorProto}, :extension_range => Base.Vector{DescriptorProto_ExtensionRange}, :oneof_decl => Base.Vector{OneofDescriptorProto}, :options => MessageOptions, :reserved_range => Base.Vector{DescriptorProto_ReservedRange}, :reserved_name => Base.Vector{AbstractString}]
-        meta(target, DescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_DescriptorProto)
+            __meta_DescriptorProto[] = target = ProtoMeta(DescriptorProto)
+            fnum = Int[1,2,6,3,4,5,8,7,9,10]
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :field => Base.Vector{FieldDescriptorProto}, :extension => Base.Vector{FieldDescriptorProto}, :nested_type => Base.Vector{DescriptorProto}, :enum_type => Base.Vector{EnumDescriptorProto}, :extension_range => Base.Vector{DescriptorProto_ExtensionRange}, :oneof_decl => Base.Vector{OneofDescriptorProto}, :options => MessageOptions, :reserved_range => Base.Vector{DescriptorProto_ReservedRange}, :reserved_name => Base.Vector{AbstractString}]
+            meta(target, DescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_DescriptorProto[]
     end
-    __meta_DescriptorProto[]
 end
 function Base.getproperty(obj::DescriptorProto, name::Symbol)
     if name === :name
@@ -924,12 +964,14 @@ mutable struct ServiceDescriptorProto <: ProtoType
 end # mutable struct ServiceDescriptorProto
 const __meta_ServiceDescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{ServiceDescriptorProto})
-    if !isassigned(__meta_ServiceDescriptorProto)
-        __meta_ServiceDescriptorProto[] = target = ProtoMeta(ServiceDescriptorProto)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :method => Base.Vector{MethodDescriptorProto}, :options => ServiceOptions]
-        meta(target, ServiceDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_ServiceDescriptorProto)
+            __meta_ServiceDescriptorProto[] = target = ProtoMeta(ServiceDescriptorProto)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :method => Base.Vector{MethodDescriptorProto}, :options => ServiceOptions]
+            meta(target, ServiceDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_ServiceDescriptorProto[]
     end
-    __meta_ServiceDescriptorProto[]
 end
 function Base.getproperty(obj::ServiceDescriptorProto, name::Symbol)
     if name === :name
@@ -962,14 +1004,16 @@ mutable struct SourceCodeInfo_Location <: ProtoType
 end # mutable struct SourceCodeInfo_Location
 const __meta_SourceCodeInfo_Location = Ref{ProtoMeta}()
 function meta(::Type{SourceCodeInfo_Location})
-    if !isassigned(__meta_SourceCodeInfo_Location)
-        __meta_SourceCodeInfo_Location[] = target = ProtoMeta(SourceCodeInfo_Location)
-        fnum = Int[1,2,3,4,6]
-        pack = Symbol[:path,:span]
-        allflds = Pair{Symbol,Union{Type,String}}[:path => Base.Vector{Int32}, :span => Base.Vector{Int32}, :leading_comments => AbstractString, :trailing_comments => AbstractString, :leading_detached_comments => Base.Vector{AbstractString}]
-        meta(target, SourceCodeInfo_Location, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, pack, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_SourceCodeInfo_Location)
+            __meta_SourceCodeInfo_Location[] = target = ProtoMeta(SourceCodeInfo_Location)
+            fnum = Int[1,2,3,4,6]
+            pack = Symbol[:path,:span]
+            allflds = Pair{Symbol,Union{Type,String}}[:path => Base.Vector{Int32}, :span => Base.Vector{Int32}, :leading_comments => AbstractString, :trailing_comments => AbstractString, :leading_detached_comments => Base.Vector{AbstractString}]
+            meta(target, SourceCodeInfo_Location, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, pack, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_SourceCodeInfo_Location[]
     end
-    __meta_SourceCodeInfo_Location[]
 end
 function Base.getproperty(obj::SourceCodeInfo_Location, name::Symbol)
     if name === :path
@@ -1006,12 +1050,14 @@ mutable struct SourceCodeInfo <: ProtoType
 end # mutable struct SourceCodeInfo
 const __meta_SourceCodeInfo = Ref{ProtoMeta}()
 function meta(::Type{SourceCodeInfo})
-    if !isassigned(__meta_SourceCodeInfo)
-        __meta_SourceCodeInfo[] = target = ProtoMeta(SourceCodeInfo)
-        allflds = Pair{Symbol,Union{Type,String}}[:location => Base.Vector{SourceCodeInfo_Location}]
-        meta(target, SourceCodeInfo, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_SourceCodeInfo)
+            __meta_SourceCodeInfo[] = target = ProtoMeta(SourceCodeInfo)
+            allflds = Pair{Symbol,Union{Type,String}}[:location => Base.Vector{SourceCodeInfo_Location}]
+            meta(target, SourceCodeInfo, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_SourceCodeInfo[]
     end
-    __meta_SourceCodeInfo[]
 end
 function Base.getproperty(obj::SourceCodeInfo, name::Symbol)
     if name === :location
@@ -1040,13 +1086,15 @@ mutable struct FileDescriptorProto <: ProtoType
 end # mutable struct FileDescriptorProto
 const __meta_FileDescriptorProto = Ref{ProtoMeta}()
 function meta(::Type{FileDescriptorProto})
-    if !isassigned(__meta_FileDescriptorProto)
-        __meta_FileDescriptorProto[] = target = ProtoMeta(FileDescriptorProto)
-        fnum = Int[1,2,3,10,11,4,5,6,7,8,9,12]
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :package => AbstractString, :dependency => Base.Vector{AbstractString}, :public_dependency => Base.Vector{Int32}, :weak_dependency => Base.Vector{Int32}, :message_type => Base.Vector{DescriptorProto}, :enum_type => Base.Vector{EnumDescriptorProto}, :service => Base.Vector{ServiceDescriptorProto}, :extension => Base.Vector{FieldDescriptorProto}, :options => FileOptions, :source_code_info => SourceCodeInfo, :syntax => AbstractString]
-        meta(target, FileDescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_FileDescriptorProto)
+            __meta_FileDescriptorProto[] = target = ProtoMeta(FileDescriptorProto)
+            fnum = Int[1,2,3,10,11,4,5,6,7,8,9,12]
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :package => AbstractString, :dependency => Base.Vector{AbstractString}, :public_dependency => Base.Vector{Int32}, :weak_dependency => Base.Vector{Int32}, :message_type => Base.Vector{DescriptorProto}, :enum_type => Base.Vector{EnumDescriptorProto}, :service => Base.Vector{ServiceDescriptorProto}, :extension => Base.Vector{FieldDescriptorProto}, :options => FileOptions, :source_code_info => SourceCodeInfo, :syntax => AbstractString]
+            meta(target, FileDescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_FileDescriptorProto[]
     end
-    __meta_FileDescriptorProto[]
 end
 function Base.getproperty(obj::FileDescriptorProto, name::Symbol)
     if name === :name
@@ -1097,12 +1145,14 @@ mutable struct FileDescriptorSet <: ProtoType
 end # mutable struct FileDescriptorSet
 const __meta_FileDescriptorSet = Ref{ProtoMeta}()
 function meta(::Type{FileDescriptorSet})
-    if !isassigned(__meta_FileDescriptorSet)
-        __meta_FileDescriptorSet[] = target = ProtoMeta(FileDescriptorSet)
-        allflds = Pair{Symbol,Union{Type,String}}[:file => Base.Vector{FileDescriptorProto}]
-        meta(target, FileDescriptorSet, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_FileDescriptorSet)
+            __meta_FileDescriptorSet[] = target = ProtoMeta(FileDescriptorSet)
+            allflds = Pair{Symbol,Union{Type,String}}[:file => Base.Vector{FileDescriptorProto}]
+            meta(target, FileDescriptorSet, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_FileDescriptorSet[]
     end
-    __meta_FileDescriptorSet[]
 end
 function Base.getproperty(obj::FileDescriptorSet, name::Symbol)
     if name === :file
@@ -1131,13 +1181,15 @@ mutable struct GeneratedCodeInfo_Annotation <: ProtoType
 end # mutable struct GeneratedCodeInfo_Annotation
 const __meta_GeneratedCodeInfo_Annotation = Ref{ProtoMeta}()
 function meta(::Type{GeneratedCodeInfo_Annotation})
-    if !isassigned(__meta_GeneratedCodeInfo_Annotation)
-        __meta_GeneratedCodeInfo_Annotation[] = target = ProtoMeta(GeneratedCodeInfo_Annotation)
-        pack = Symbol[:path]
-        allflds = Pair{Symbol,Union{Type,String}}[:path => Base.Vector{Int32}, :source_file => AbstractString, :_begin => Int32, :_end => Int32]
-        meta(target, GeneratedCodeInfo_Annotation, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, pack, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_GeneratedCodeInfo_Annotation)
+            __meta_GeneratedCodeInfo_Annotation[] = target = ProtoMeta(GeneratedCodeInfo_Annotation)
+            pack = Symbol[:path]
+            allflds = Pair{Symbol,Union{Type,String}}[:path => Base.Vector{Int32}, :source_file => AbstractString, :_begin => Int32, :_end => Int32]
+            meta(target, GeneratedCodeInfo_Annotation, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, pack, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_GeneratedCodeInfo_Annotation[]
     end
-    __meta_GeneratedCodeInfo_Annotation[]
 end
 function Base.getproperty(obj::GeneratedCodeInfo_Annotation, name::Symbol)
     if name === :path
@@ -1172,12 +1224,14 @@ mutable struct GeneratedCodeInfo <: ProtoType
 end # mutable struct GeneratedCodeInfo
 const __meta_GeneratedCodeInfo = Ref{ProtoMeta}()
 function meta(::Type{GeneratedCodeInfo})
-    if !isassigned(__meta_GeneratedCodeInfo)
-        __meta_GeneratedCodeInfo[] = target = ProtoMeta(GeneratedCodeInfo)
-        allflds = Pair{Symbol,Union{Type,String}}[:annotation => Base.Vector{GeneratedCodeInfo_Annotation}]
-        meta(target, GeneratedCodeInfo, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_GeneratedCodeInfo)
+            __meta_GeneratedCodeInfo[] = target = ProtoMeta(GeneratedCodeInfo)
+            allflds = Pair{Symbol,Union{Type,String}}[:annotation => Base.Vector{GeneratedCodeInfo_Annotation}]
+            meta(target, GeneratedCodeInfo, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_GeneratedCodeInfo[]
     end
-    __meta_GeneratedCodeInfo[]
 end
 function Base.getproperty(obj::GeneratedCodeInfo, name::Symbol)
     if name === :annotation

--- a/src/google/descriptor_pb.jl
+++ b/src/google/descriptor_pb.jl
@@ -1,339 +1,1190 @@
 # syntax: proto2
 mutable struct UninterpretedOption_NamePart <: ProtoType
-    name_part::AbstractString
-    is_extension::Bool
-    UninterpretedOption_NamePart(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct UninterpretedOption_NamePart
-const __req_UninterpretedOption_NamePart = Symbol[:name_part,:is_extension]
-meta(t::Type{UninterpretedOption_NamePart}) = meta(t, __req_UninterpretedOption_NamePart, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function UninterpretedOption_NamePart(; kwargs...)
+        obj = new(meta(UninterpretedOption_NamePart), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct UninterpretedOption_NamePart
+const __meta_UninterpretedOption_NamePart = Ref{ProtoMeta}()
+function meta(::Type{UninterpretedOption_NamePart})
+    if !isassigned(__meta_UninterpretedOption_NamePart)
+        __meta_UninterpretedOption_NamePart[] = target = ProtoMeta(UninterpretedOption_NamePart)
+        req = Symbol[:name_part,:is_extension]
+        allflds = Pair{Symbol,Union{Type,String}}[:name_part => AbstractString, :is_extension => Bool]
+        meta(target, UninterpretedOption_NamePart, allflds, req, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_UninterpretedOption_NamePart[]
+end
+function Base.getproperty(obj::UninterpretedOption_NamePart, name::Symbol)
+    if name === :name_part
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :is_extension
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct UninterpretedOption <: ProtoType
-    name::Base.Vector{UninterpretedOption_NamePart}
-    identifier_value::AbstractString
-    positive_int_value::UInt64
-    negative_int_value::Int64
-    double_value::Float64
-    string_value::Array{UInt8,1}
-    aggregate_value::AbstractString
-    UninterpretedOption(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct UninterpretedOption
-const __fnum_UninterpretedOption = Int[2,3,4,5,6,7,8]
-meta(t::Type{UninterpretedOption}) = meta(t, ProtoBuf.DEF_REQ, __fnum_UninterpretedOption, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
 
-struct __enum_FieldOptions_CType <: ProtoEnum
-    STRING::Int32
-    CORD::Int32
-    STRING_PIECE::Int32
-    __enum_FieldOptions_CType() = new(0,1,2)
-end #struct __enum_FieldOptions_CType
-const FieldOptions_CType = __enum_FieldOptions_CType()
+    function UninterpretedOption(; kwargs...)
+        obj = new(meta(UninterpretedOption), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct UninterpretedOption
+const __meta_UninterpretedOption = Ref{ProtoMeta}()
+function meta(::Type{UninterpretedOption})
+    if !isassigned(__meta_UninterpretedOption)
+        __meta_UninterpretedOption[] = target = ProtoMeta(UninterpretedOption)
+        fnum = Int[2,3,4,5,6,7,8]
+        allflds = Pair{Symbol,Union{Type,String}}[:name => Base.Vector{UninterpretedOption_NamePart}, :identifier_value => AbstractString, :positive_int_value => UInt64, :negative_int_value => Int64, :double_value => Float64, :string_value => Array{UInt8,1}, :aggregate_value => AbstractString]
+        meta(target, UninterpretedOption, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_UninterpretedOption[]
+end
+function Base.getproperty(obj::UninterpretedOption, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption_NamePart}
+    elseif name === :identifier_value
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :positive_int_value
+        return (obj.__protobuf_jl_internal_values[name])::UInt64
+    elseif name === :negative_int_value
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :double_value
+        return (obj.__protobuf_jl_internal_values[name])::Float64
+    elseif name === :string_value
+        return (obj.__protobuf_jl_internal_values[name])::Array{UInt8,1}
+    elseif name === :aggregate_value
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
-struct __enum_FieldOptions_JSType <: ProtoEnum
-    JS_NORMAL::Int32
-    JS_STRING::Int32
-    JS_NUMBER::Int32
-    __enum_FieldOptions_JSType() = new(0,1,2)
-end #struct __enum_FieldOptions_JSType
-const FieldOptions_JSType = __enum_FieldOptions_JSType()
+const FieldOptions_CType = (;[
+    Symbol("STRING") => Int32(0),
+    Symbol("CORD") => Int32(1),
+    Symbol("STRING_PIECE") => Int32(2),
+]...)
+
+const FieldOptions_JSType = (;[
+    Symbol("JS_NORMAL") => Int32(0),
+    Symbol("JS_STRING") => Int32(1),
+    Symbol("JS_NUMBER") => Int32(2),
+]...)
 
 mutable struct FieldOptions <: ProtoType
-    ctype::Int32
-    packed::Bool
-    jstype::Int32
-    lazy::Bool
-    deprecated::Bool
-    weak::Bool
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    FieldOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct FieldOptions
-const __val_FieldOptions = Dict(:ctype => FieldOptions_CType.STRING, :jstype => FieldOptions_JSType.JS_NORMAL, :lazy => false, :deprecated => false, :weak => false)
-const __fnum_FieldOptions = Int[1,2,6,5,3,10,999]
-meta(t::Type{FieldOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FieldOptions, __val_FieldOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function FieldOptions(; kwargs...)
+        obj = new(meta(FieldOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct FieldOptions
+const __meta_FieldOptions = Ref{ProtoMeta}()
+function meta(::Type{FieldOptions})
+    if !isassigned(__meta_FieldOptions)
+        __meta_FieldOptions[] = target = ProtoMeta(FieldOptions)
+        val = Dict{Symbol,Any}(:ctype => FieldOptions_CType.STRING, :jstype => FieldOptions_JSType.JS_NORMAL, :lazy => false, :deprecated => false, :weak => false)
+        fnum = Int[1,2,6,5,3,10,999]
+        allflds = Pair{Symbol,Union{Type,String}}[:ctype => Int32, :packed => Bool, :jstype => Int32, :lazy => Bool, :deprecated => Bool, :weak => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, FieldOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_FieldOptions[]
+end
+function Base.getproperty(obj::FieldOptions, name::Symbol)
+    if name === :ctype
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :packed
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :jstype
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :lazy
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :deprecated
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :weak
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct MessageOptions <: ProtoType
-    message_set_wire_format::Bool
-    no_standard_descriptor_accessor::Bool
-    deprecated::Bool
-    map_entry::Bool
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    MessageOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct MessageOptions
-const __val_MessageOptions = Dict(:message_set_wire_format => false, :no_standard_descriptor_accessor => false, :deprecated => false)
-const __fnum_MessageOptions = Int[1,2,3,7,999]
-meta(t::Type{MessageOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_MessageOptions, __val_MessageOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function MessageOptions(; kwargs...)
+        obj = new(meta(MessageOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct MessageOptions
+const __meta_MessageOptions = Ref{ProtoMeta}()
+function meta(::Type{MessageOptions})
+    if !isassigned(__meta_MessageOptions)
+        __meta_MessageOptions[] = target = ProtoMeta(MessageOptions)
+        val = Dict{Symbol,Any}(:message_set_wire_format => false, :no_standard_descriptor_accessor => false, :deprecated => false)
+        fnum = Int[1,2,3,7,999]
+        allflds = Pair{Symbol,Union{Type,String}}[:message_set_wire_format => Bool, :no_standard_descriptor_accessor => Bool, :deprecated => Bool, :map_entry => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, MessageOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_MessageOptions[]
+end
+function Base.getproperty(obj::MessageOptions, name::Symbol)
+    if name === :message_set_wire_format
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :no_standard_descriptor_accessor
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :deprecated
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :map_entry
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct EnumOptions <: ProtoType
-    allow_alias::Bool
-    deprecated::Bool
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    EnumOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct EnumOptions
-const __val_EnumOptions = Dict(:deprecated => false)
-const __fnum_EnumOptions = Int[2,3,999]
-meta(t::Type{EnumOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_EnumOptions, __val_EnumOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function EnumOptions(; kwargs...)
+        obj = new(meta(EnumOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct EnumOptions
+const __meta_EnumOptions = Ref{ProtoMeta}()
+function meta(::Type{EnumOptions})
+    if !isassigned(__meta_EnumOptions)
+        __meta_EnumOptions[] = target = ProtoMeta(EnumOptions)
+        val = Dict{Symbol,Any}(:deprecated => false)
+        fnum = Int[2,3,999]
+        allflds = Pair{Symbol,Union{Type,String}}[:allow_alias => Bool, :deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, EnumOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_EnumOptions[]
+end
+function Base.getproperty(obj::EnumOptions, name::Symbol)
+    if name === :allow_alias
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :deprecated
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct ExtensionRangeOptions <: ProtoType
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    ExtensionRangeOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ExtensionRangeOptions
-const __fnum_ExtensionRangeOptions = Int[999]
-meta(t::Type{ExtensionRangeOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_ExtensionRangeOptions, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
 
-struct __enum_MethodOptions_IdempotencyLevel <: ProtoEnum
-    IDEMPOTENCY_UNKNOWN::Int32
-    NO_SIDE_EFFECTS::Int32
-    IDEMPOTENT::Int32
-    __enum_MethodOptions_IdempotencyLevel() = new(0,1,2)
-end #struct __enum_MethodOptions_IdempotencyLevel
-const MethodOptions_IdempotencyLevel = __enum_MethodOptions_IdempotencyLevel()
+    function ExtensionRangeOptions(; kwargs...)
+        obj = new(meta(ExtensionRangeOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct ExtensionRangeOptions
+const __meta_ExtensionRangeOptions = Ref{ProtoMeta}()
+function meta(::Type{ExtensionRangeOptions})
+    if !isassigned(__meta_ExtensionRangeOptions)
+        __meta_ExtensionRangeOptions[] = target = ProtoMeta(ExtensionRangeOptions)
+        fnum = Int[999]
+        allflds = Pair{Symbol,Union{Type,String}}[:uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, ExtensionRangeOptions, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_ExtensionRangeOptions[]
+end
+function Base.getproperty(obj::ExtensionRangeOptions, name::Symbol)
+    if name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
+
+const MethodOptions_IdempotencyLevel = (;[
+    Symbol("IDEMPOTENCY_UNKNOWN") => Int32(0),
+    Symbol("NO_SIDE_EFFECTS") => Int32(1),
+    Symbol("IDEMPOTENT") => Int32(2),
+]...)
 
 mutable struct MethodOptions <: ProtoType
-    deprecated::Bool
-    idempotency_level::Int32
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    MethodOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct MethodOptions
-const __val_MethodOptions = Dict(:deprecated => false, :idempotency_level => MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN)
-const __fnum_MethodOptions = Int[33,34,999]
-meta(t::Type{MethodOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_MethodOptions, __val_MethodOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
 
-struct __enum_FileOptions_OptimizeMode <: ProtoEnum
-    SPEED::Int32
-    CODE_SIZE::Int32
-    LITE_RUNTIME::Int32
-    __enum_FileOptions_OptimizeMode() = new(1,2,3)
-end #struct __enum_FileOptions_OptimizeMode
-const FileOptions_OptimizeMode = __enum_FileOptions_OptimizeMode()
+    function MethodOptions(; kwargs...)
+        obj = new(meta(MethodOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct MethodOptions
+const __meta_MethodOptions = Ref{ProtoMeta}()
+function meta(::Type{MethodOptions})
+    if !isassigned(__meta_MethodOptions)
+        __meta_MethodOptions[] = target = ProtoMeta(MethodOptions)
+        val = Dict{Symbol,Any}(:deprecated => false, :idempotency_level => MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN)
+        fnum = Int[33,34,999]
+        allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :idempotency_level => Int32, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, MethodOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_MethodOptions[]
+end
+function Base.getproperty(obj::MethodOptions, name::Symbol)
+    if name === :deprecated
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :idempotency_level
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
+
+const FileOptions_OptimizeMode = (;[
+    Symbol("SPEED") => Int32(1),
+    Symbol("CODE_SIZE") => Int32(2),
+    Symbol("LITE_RUNTIME") => Int32(3),
+]...)
 
 mutable struct FileOptions <: ProtoType
-    java_package::AbstractString
-    java_outer_classname::AbstractString
-    java_multiple_files::Bool
-    java_generate_equals_and_hash::Bool
-    java_string_check_utf8::Bool
-    optimize_for::Int32
-    go_package::AbstractString
-    cc_generic_services::Bool
-    java_generic_services::Bool
-    py_generic_services::Bool
-    php_generic_services::Bool
-    deprecated::Bool
-    cc_enable_arenas::Bool
-    objc_class_prefix::AbstractString
-    csharp_namespace::AbstractString
-    swift_prefix::AbstractString
-    php_class_prefix::AbstractString
-    php_namespace::AbstractString
-    php_metadata_namespace::AbstractString
-    ruby_package::AbstractString
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    FileOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct FileOptions
-const __val_FileOptions = Dict(:java_multiple_files => false, :java_string_check_utf8 => false, :optimize_for => FileOptions_OptimizeMode.SPEED, :cc_generic_services => false, :java_generic_services => false, :py_generic_services => false, :php_generic_services => false, :deprecated => false, :cc_enable_arenas => false)
-const __fnum_FileOptions = Int[1,8,10,20,27,9,11,16,17,18,42,23,31,36,37,39,40,41,44,45,999]
-meta(t::Type{FileOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FileOptions, __val_FileOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function FileOptions(; kwargs...)
+        obj = new(meta(FileOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct FileOptions
+const __meta_FileOptions = Ref{ProtoMeta}()
+function meta(::Type{FileOptions})
+    if !isassigned(__meta_FileOptions)
+        __meta_FileOptions[] = target = ProtoMeta(FileOptions)
+        val = Dict{Symbol,Any}(:java_multiple_files => false, :java_string_check_utf8 => false, :optimize_for => FileOptions_OptimizeMode.SPEED, :cc_generic_services => false, :java_generic_services => false, :py_generic_services => false, :php_generic_services => false, :deprecated => false, :cc_enable_arenas => false)
+        fnum = Int[1,8,10,20,27,9,11,16,17,18,42,23,31,36,37,39,40,41,44,45,999]
+        allflds = Pair{Symbol,Union{Type,String}}[:java_package => AbstractString, :java_outer_classname => AbstractString, :java_multiple_files => Bool, :java_generate_equals_and_hash => Bool, :java_string_check_utf8 => Bool, :optimize_for => Int32, :go_package => AbstractString, :cc_generic_services => Bool, :java_generic_services => Bool, :py_generic_services => Bool, :php_generic_services => Bool, :deprecated => Bool, :cc_enable_arenas => Bool, :objc_class_prefix => AbstractString, :csharp_namespace => AbstractString, :swift_prefix => AbstractString, :php_class_prefix => AbstractString, :php_namespace => AbstractString, :php_metadata_namespace => AbstractString, :ruby_package => AbstractString, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, FileOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_FileOptions[]
+end
+function Base.getproperty(obj::FileOptions, name::Symbol)
+    if name === :java_package
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :java_outer_classname
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :java_multiple_files
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :java_generate_equals_and_hash
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :java_string_check_utf8
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :optimize_for
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :go_package
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :cc_generic_services
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :java_generic_services
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :py_generic_services
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :php_generic_services
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :deprecated
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :cc_enable_arenas
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :objc_class_prefix
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :csharp_namespace
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :swift_prefix
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :php_class_prefix
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :php_namespace
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :php_metadata_namespace
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :ruby_package
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct EnumValueOptions <: ProtoType
-    deprecated::Bool
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    EnumValueOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct EnumValueOptions
-const __val_EnumValueOptions = Dict(:deprecated => false)
-const __fnum_EnumValueOptions = Int[1,999]
-meta(t::Type{EnumValueOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_EnumValueOptions, __val_EnumValueOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function EnumValueOptions(; kwargs...)
+        obj = new(meta(EnumValueOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct EnumValueOptions
+const __meta_EnumValueOptions = Ref{ProtoMeta}()
+function meta(::Type{EnumValueOptions})
+    if !isassigned(__meta_EnumValueOptions)
+        __meta_EnumValueOptions[] = target = ProtoMeta(EnumValueOptions)
+        val = Dict{Symbol,Any}(:deprecated => false)
+        fnum = Int[1,999]
+        allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, EnumValueOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_EnumValueOptions[]
+end
+function Base.getproperty(obj::EnumValueOptions, name::Symbol)
+    if name === :deprecated
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct OneofOptions <: ProtoType
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    OneofOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct OneofOptions
-const __fnum_OneofOptions = Int[999]
-meta(t::Type{OneofOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_OneofOptions, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function OneofOptions(; kwargs...)
+        obj = new(meta(OneofOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct OneofOptions
+const __meta_OneofOptions = Ref{ProtoMeta}()
+function meta(::Type{OneofOptions})
+    if !isassigned(__meta_OneofOptions)
+        __meta_OneofOptions[] = target = ProtoMeta(OneofOptions)
+        fnum = Int[999]
+        allflds = Pair{Symbol,Union{Type,String}}[:uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, OneofOptions, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_OneofOptions[]
+end
+function Base.getproperty(obj::OneofOptions, name::Symbol)
+    if name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct ServiceOptions <: ProtoType
-    deprecated::Bool
-    uninterpreted_option::Base.Vector{UninterpretedOption}
-    ServiceOptions(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ServiceOptions
-const __val_ServiceOptions = Dict(:deprecated => false)
-const __fnum_ServiceOptions = Int[33,999]
-meta(t::Type{ServiceOptions}) = meta(t, ProtoBuf.DEF_REQ, __fnum_ServiceOptions, __val_ServiceOptions, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
 
-struct __enum_FieldDescriptorProto_Type <: ProtoEnum
-    TYPE_DOUBLE::Int32
-    TYPE_FLOAT::Int32
-    TYPE_INT64::Int32
-    TYPE_UINT64::Int32
-    TYPE_INT32::Int32
-    TYPE_FIXED64::Int32
-    TYPE_FIXED32::Int32
-    TYPE_BOOL::Int32
-    TYPE_STRING::Int32
-    TYPE_GROUP::Int32
-    TYPE_MESSAGE::Int32
-    TYPE_BYTES::Int32
-    TYPE_UINT32::Int32
-    TYPE_ENUM::Int32
-    TYPE_SFIXED32::Int32
-    TYPE_SFIXED64::Int32
-    TYPE_SINT32::Int32
-    TYPE_SINT64::Int32
-    __enum_FieldDescriptorProto_Type() = new(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18)
-end #struct __enum_FieldDescriptorProto_Type
-const FieldDescriptorProto_Type = __enum_FieldDescriptorProto_Type()
+    function ServiceOptions(; kwargs...)
+        obj = new(meta(ServiceOptions), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct ServiceOptions
+const __meta_ServiceOptions = Ref{ProtoMeta}()
+function meta(::Type{ServiceOptions})
+    if !isassigned(__meta_ServiceOptions)
+        __meta_ServiceOptions[] = target = ProtoMeta(ServiceOptions)
+        val = Dict{Symbol,Any}(:deprecated => false)
+        fnum = Int[33,999]
+        allflds = Pair{Symbol,Union{Type,String}}[:deprecated => Bool, :uninterpreted_option => Base.Vector{UninterpretedOption}]
+        meta(target, ServiceOptions, allflds, ProtoBuf.DEF_REQ, fnum, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_ServiceOptions[]
+end
+function Base.getproperty(obj::ServiceOptions, name::Symbol)
+    if name === :deprecated
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :uninterpreted_option
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{UninterpretedOption}
+    else
+        getfield(obj, name)
+    end
+end
 
-struct __enum_FieldDescriptorProto_Label <: ProtoEnum
-    LABEL_OPTIONAL::Int32
-    LABEL_REQUIRED::Int32
-    LABEL_REPEATED::Int32
-    __enum_FieldDescriptorProto_Label() = new(1,2,3)
-end #struct __enum_FieldDescriptorProto_Label
-const FieldDescriptorProto_Label = __enum_FieldDescriptorProto_Label()
+const FieldDescriptorProto_Type = (;[
+    Symbol("TYPE_DOUBLE") => Int32(1),
+    Symbol("TYPE_FLOAT") => Int32(2),
+    Symbol("TYPE_INT64") => Int32(3),
+    Symbol("TYPE_UINT64") => Int32(4),
+    Symbol("TYPE_INT32") => Int32(5),
+    Symbol("TYPE_FIXED64") => Int32(6),
+    Symbol("TYPE_FIXED32") => Int32(7),
+    Symbol("TYPE_BOOL") => Int32(8),
+    Symbol("TYPE_STRING") => Int32(9),
+    Symbol("TYPE_GROUP") => Int32(10),
+    Symbol("TYPE_MESSAGE") => Int32(11),
+    Symbol("TYPE_BYTES") => Int32(12),
+    Symbol("TYPE_UINT32") => Int32(13),
+    Symbol("TYPE_ENUM") => Int32(14),
+    Symbol("TYPE_SFIXED32") => Int32(15),
+    Symbol("TYPE_SFIXED64") => Int32(16),
+    Symbol("TYPE_SINT32") => Int32(17),
+    Symbol("TYPE_SINT64") => Int32(18),
+]...)
+
+const FieldDescriptorProto_Label = (;[
+    Symbol("LABEL_OPTIONAL") => Int32(1),
+    Symbol("LABEL_REQUIRED") => Int32(2),
+    Symbol("LABEL_REPEATED") => Int32(3),
+]...)
 
 mutable struct FieldDescriptorProto <: ProtoType
-    name::AbstractString
-    number::Int32
-    label::Int32
-    _type::Int32
-    type_name::AbstractString
-    extendee::AbstractString
-    default_value::AbstractString
-    oneof_index::Int32
-    json_name::AbstractString
-    options::FieldOptions
-    FieldDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct FieldDescriptorProto
-const __fnum_FieldDescriptorProto = Int[1,3,4,5,6,2,7,9,10,8]
-meta(t::Type{FieldDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FieldDescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function FieldDescriptorProto(; kwargs...)
+        obj = new(meta(FieldDescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct FieldDescriptorProto
+const __meta_FieldDescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{FieldDescriptorProto})
+    if !isassigned(__meta_FieldDescriptorProto)
+        __meta_FieldDescriptorProto[] = target = ProtoMeta(FieldDescriptorProto)
+        fnum = Int[1,3,4,5,6,2,7,9,10,8]
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :label => Int32, :_type => Int32, :type_name => AbstractString, :extendee => AbstractString, :default_value => AbstractString, :oneof_index => Int32, :json_name => AbstractString, :options => FieldOptions]
+        meta(target, FieldDescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_FieldDescriptorProto[]
+end
+function Base.getproperty(obj::FieldDescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :number
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :label
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :_type
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :type_name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :extendee
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :default_value
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :oneof_index
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :json_name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::FieldOptions
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct DescriptorProto_ExtensionRange <: ProtoType
-    start::Int32
-    _end::Int32
-    options::ExtensionRangeOptions
-    DescriptorProto_ExtensionRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct DescriptorProto_ExtensionRange
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function DescriptorProto_ExtensionRange(; kwargs...)
+        obj = new(meta(DescriptorProto_ExtensionRange), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct DescriptorProto_ExtensionRange
+const __meta_DescriptorProto_ExtensionRange = Ref{ProtoMeta}()
+function meta(::Type{DescriptorProto_ExtensionRange})
+    if !isassigned(__meta_DescriptorProto_ExtensionRange)
+        __meta_DescriptorProto_ExtensionRange[] = target = ProtoMeta(DescriptorProto_ExtensionRange)
+        allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32, :options => ExtensionRangeOptions]
+        meta(target, DescriptorProto_ExtensionRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_DescriptorProto_ExtensionRange[]
+end
+function Base.getproperty(obj::DescriptorProto_ExtensionRange, name::Symbol)
+    if name === :start
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :_end
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::ExtensionRangeOptions
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct MethodDescriptorProto <: ProtoType
-    name::AbstractString
-    input_type::AbstractString
-    output_type::AbstractString
-    options::MethodOptions
-    client_streaming::Bool
-    server_streaming::Bool
-    MethodDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct MethodDescriptorProto
-const __val_MethodDescriptorProto = Dict(:client_streaming => false, :server_streaming => false)
-meta(t::Type{MethodDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, __val_MethodDescriptorProto, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function MethodDescriptorProto(; kwargs...)
+        obj = new(meta(MethodDescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct MethodDescriptorProto
+const __meta_MethodDescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{MethodDescriptorProto})
+    if !isassigned(__meta_MethodDescriptorProto)
+        __meta_MethodDescriptorProto[] = target = ProtoMeta(MethodDescriptorProto)
+        val = Dict{Symbol,Any}(:client_streaming => false, :server_streaming => false)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :input_type => AbstractString, :output_type => AbstractString, :options => MethodOptions, :client_streaming => Bool, :server_streaming => Bool]
+        meta(target, MethodDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, val, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_MethodDescriptorProto[]
+end
+function Base.getproperty(obj::MethodDescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :input_type
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :output_type
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::MethodOptions
+    elseif name === :client_streaming
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :server_streaming
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct EnumValueDescriptorProto <: ProtoType
-    name::AbstractString
-    number::Int32
-    options::EnumValueOptions
-    EnumValueDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct EnumValueDescriptorProto
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function EnumValueDescriptorProto(; kwargs...)
+        obj = new(meta(EnumValueDescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct EnumValueDescriptorProto
+const __meta_EnumValueDescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{EnumValueDescriptorProto})
+    if !isassigned(__meta_EnumValueDescriptorProto)
+        __meta_EnumValueDescriptorProto[] = target = ProtoMeta(EnumValueDescriptorProto)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :options => EnumValueOptions]
+        meta(target, EnumValueDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_EnumValueDescriptorProto[]
+end
+function Base.getproperty(obj::EnumValueDescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :number
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::EnumValueOptions
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct EnumDescriptorProto_EnumReservedRange <: ProtoType
-    start::Int32
-    _end::Int32
-    EnumDescriptorProto_EnumReservedRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct EnumDescriptorProto_EnumReservedRange
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function EnumDescriptorProto_EnumReservedRange(; kwargs...)
+        obj = new(meta(EnumDescriptorProto_EnumReservedRange), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct EnumDescriptorProto_EnumReservedRange
+const __meta_EnumDescriptorProto_EnumReservedRange = Ref{ProtoMeta}()
+function meta(::Type{EnumDescriptorProto_EnumReservedRange})
+    if !isassigned(__meta_EnumDescriptorProto_EnumReservedRange)
+        __meta_EnumDescriptorProto_EnumReservedRange[] = target = ProtoMeta(EnumDescriptorProto_EnumReservedRange)
+        allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32]
+        meta(target, EnumDescriptorProto_EnumReservedRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_EnumDescriptorProto_EnumReservedRange[]
+end
+function Base.getproperty(obj::EnumDescriptorProto_EnumReservedRange, name::Symbol)
+    if name === :start
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :_end
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct EnumDescriptorProto <: ProtoType
-    name::AbstractString
-    value::Base.Vector{EnumValueDescriptorProto}
-    options::EnumOptions
-    reserved_range::Base.Vector{EnumDescriptorProto_EnumReservedRange}
-    reserved_name::Base.Vector{AbstractString}
-    EnumDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct EnumDescriptorProto
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function EnumDescriptorProto(; kwargs...)
+        obj = new(meta(EnumDescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct EnumDescriptorProto
+const __meta_EnumDescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{EnumDescriptorProto})
+    if !isassigned(__meta_EnumDescriptorProto)
+        __meta_EnumDescriptorProto[] = target = ProtoMeta(EnumDescriptorProto)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :value => Base.Vector{EnumValueDescriptorProto}, :options => EnumOptions, :reserved_range => Base.Vector{EnumDescriptorProto_EnumReservedRange}, :reserved_name => Base.Vector{AbstractString}]
+        meta(target, EnumDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_EnumDescriptorProto[]
+end
+function Base.getproperty(obj::EnumDescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{EnumValueDescriptorProto}
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::EnumOptions
+    elseif name === :reserved_range
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{EnumDescriptorProto_EnumReservedRange}
+    elseif name === :reserved_name
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{AbstractString}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct OneofDescriptorProto <: ProtoType
-    name::AbstractString
-    options::OneofOptions
-    OneofDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct OneofDescriptorProto
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function OneofDescriptorProto(; kwargs...)
+        obj = new(meta(OneofDescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct OneofDescriptorProto
+const __meta_OneofDescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{OneofDescriptorProto})
+    if !isassigned(__meta_OneofDescriptorProto)
+        __meta_OneofDescriptorProto[] = target = ProtoMeta(OneofDescriptorProto)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :options => OneofOptions]
+        meta(target, OneofDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_OneofDescriptorProto[]
+end
+function Base.getproperty(obj::OneofDescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::OneofOptions
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct DescriptorProto_ReservedRange <: ProtoType
-    start::Int32
-    _end::Int32
-    DescriptorProto_ReservedRange(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct DescriptorProto_ReservedRange
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function DescriptorProto_ReservedRange(; kwargs...)
+        obj = new(meta(DescriptorProto_ReservedRange), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct DescriptorProto_ReservedRange
+const __meta_DescriptorProto_ReservedRange = Ref{ProtoMeta}()
+function meta(::Type{DescriptorProto_ReservedRange})
+    if !isassigned(__meta_DescriptorProto_ReservedRange)
+        __meta_DescriptorProto_ReservedRange[] = target = ProtoMeta(DescriptorProto_ReservedRange)
+        allflds = Pair{Symbol,Union{Type,String}}[:start => Int32, :_end => Int32]
+        meta(target, DescriptorProto_ReservedRange, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_DescriptorProto_ReservedRange[]
+end
+function Base.getproperty(obj::DescriptorProto_ReservedRange, name::Symbol)
+    if name === :start
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :_end
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct DescriptorProto <: ProtoType
-    name::AbstractString
-    field::Base.Vector{FieldDescriptorProto}
-    extension::Base.Vector{FieldDescriptorProto}
-    nested_type::Base.Vector{DescriptorProto}
-    enum_type::Base.Vector{EnumDescriptorProto}
-    extension_range::Base.Vector{DescriptorProto_ExtensionRange}
-    oneof_decl::Base.Vector{OneofDescriptorProto}
-    options::MessageOptions
-    reserved_range::Base.Vector{DescriptorProto_ReservedRange}
-    reserved_name::Base.Vector{AbstractString}
-    DescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct DescriptorProto
-const __fnum_DescriptorProto = Int[1,2,6,3,4,5,8,7,9,10]
-meta(t::Type{DescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_DescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function DescriptorProto(; kwargs...)
+        obj = new(meta(DescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct DescriptorProto
+const __meta_DescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{DescriptorProto})
+    if !isassigned(__meta_DescriptorProto)
+        __meta_DescriptorProto[] = target = ProtoMeta(DescriptorProto)
+        fnum = Int[1,2,6,3,4,5,8,7,9,10]
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :field => Base.Vector{FieldDescriptorProto}, :extension => Base.Vector{FieldDescriptorProto}, :nested_type => Base.Vector{DescriptorProto}, :enum_type => Base.Vector{EnumDescriptorProto}, :extension_range => Base.Vector{DescriptorProto_ExtensionRange}, :oneof_decl => Base.Vector{OneofDescriptorProto}, :options => MessageOptions, :reserved_range => Base.Vector{DescriptorProto_ReservedRange}, :reserved_name => Base.Vector{AbstractString}]
+        meta(target, DescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_DescriptorProto[]
+end
+function Base.getproperty(obj::DescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :field
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{FieldDescriptorProto}
+    elseif name === :extension
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{FieldDescriptorProto}
+    elseif name === :nested_type
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{DescriptorProto}
+    elseif name === :enum_type
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{EnumDescriptorProto}
+    elseif name === :extension_range
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{DescriptorProto_ExtensionRange}
+    elseif name === :oneof_decl
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{OneofDescriptorProto}
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::MessageOptions
+    elseif name === :reserved_range
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{DescriptorProto_ReservedRange}
+    elseif name === :reserved_name
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{AbstractString}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct ServiceDescriptorProto <: ProtoType
-    name::AbstractString
-    method::Base.Vector{MethodDescriptorProto}
-    options::ServiceOptions
-    ServiceDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ServiceDescriptorProto
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function ServiceDescriptorProto(; kwargs...)
+        obj = new(meta(ServiceDescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct ServiceDescriptorProto
+const __meta_ServiceDescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{ServiceDescriptorProto})
+    if !isassigned(__meta_ServiceDescriptorProto)
+        __meta_ServiceDescriptorProto[] = target = ProtoMeta(ServiceDescriptorProto)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :method => Base.Vector{MethodDescriptorProto}, :options => ServiceOptions]
+        meta(target, ServiceDescriptorProto, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_ServiceDescriptorProto[]
+end
+function Base.getproperty(obj::ServiceDescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :method
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{MethodDescriptorProto}
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::ServiceOptions
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct SourceCodeInfo_Location <: ProtoType
-    path::Base.Vector{Int32}
-    span::Base.Vector{Int32}
-    leading_comments::AbstractString
-    trailing_comments::AbstractString
-    leading_detached_comments::Base.Vector{AbstractString}
-    SourceCodeInfo_Location(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct SourceCodeInfo_Location
-const __fnum_SourceCodeInfo_Location = Int[1,2,3,4,6]
-const __pack_SourceCodeInfo_Location = Symbol[:path,:span]
-meta(t::Type{SourceCodeInfo_Location}) = meta(t, ProtoBuf.DEF_REQ, __fnum_SourceCodeInfo_Location, ProtoBuf.DEF_VAL, true, __pack_SourceCodeInfo_Location, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function SourceCodeInfo_Location(; kwargs...)
+        obj = new(meta(SourceCodeInfo_Location), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct SourceCodeInfo_Location
+const __meta_SourceCodeInfo_Location = Ref{ProtoMeta}()
+function meta(::Type{SourceCodeInfo_Location})
+    if !isassigned(__meta_SourceCodeInfo_Location)
+        __meta_SourceCodeInfo_Location[] = target = ProtoMeta(SourceCodeInfo_Location)
+        fnum = Int[1,2,3,4,6]
+        pack = Symbol[:path,:span]
+        allflds = Pair{Symbol,Union{Type,String}}[:path => Base.Vector{Int32}, :span => Base.Vector{Int32}, :leading_comments => AbstractString, :trailing_comments => AbstractString, :leading_detached_comments => Base.Vector{AbstractString}]
+        meta(target, SourceCodeInfo_Location, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, pack, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_SourceCodeInfo_Location[]
+end
+function Base.getproperty(obj::SourceCodeInfo_Location, name::Symbol)
+    if name === :path
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Int32}
+    elseif name === :span
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Int32}
+    elseif name === :leading_comments
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :trailing_comments
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :leading_detached_comments
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{AbstractString}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct SourceCodeInfo <: ProtoType
-    location::Base.Vector{SourceCodeInfo_Location}
-    SourceCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct SourceCodeInfo
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function SourceCodeInfo(; kwargs...)
+        obj = new(meta(SourceCodeInfo), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct SourceCodeInfo
+const __meta_SourceCodeInfo = Ref{ProtoMeta}()
+function meta(::Type{SourceCodeInfo})
+    if !isassigned(__meta_SourceCodeInfo)
+        __meta_SourceCodeInfo[] = target = ProtoMeta(SourceCodeInfo)
+        allflds = Pair{Symbol,Union{Type,String}}[:location => Base.Vector{SourceCodeInfo_Location}]
+        meta(target, SourceCodeInfo, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_SourceCodeInfo[]
+end
+function Base.getproperty(obj::SourceCodeInfo, name::Symbol)
+    if name === :location
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{SourceCodeInfo_Location}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct FileDescriptorProto <: ProtoType
-    name::AbstractString
-    package::AbstractString
-    dependency::Base.Vector{AbstractString}
-    public_dependency::Base.Vector{Int32}
-    weak_dependency::Base.Vector{Int32}
-    message_type::Base.Vector{DescriptorProto}
-    enum_type::Base.Vector{EnumDescriptorProto}
-    service::Base.Vector{ServiceDescriptorProto}
-    extension::Base.Vector{FieldDescriptorProto}
-    options::FileOptions
-    source_code_info::SourceCodeInfo
-    syntax::AbstractString
-    FileDescriptorProto(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct FileDescriptorProto
-const __fnum_FileDescriptorProto = Int[1,2,3,10,11,4,5,6,7,8,9,12]
-meta(t::Type{FileDescriptorProto}) = meta(t, ProtoBuf.DEF_REQ, __fnum_FileDescriptorProto, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function FileDescriptorProto(; kwargs...)
+        obj = new(meta(FileDescriptorProto), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct FileDescriptorProto
+const __meta_FileDescriptorProto = Ref{ProtoMeta}()
+function meta(::Type{FileDescriptorProto})
+    if !isassigned(__meta_FileDescriptorProto)
+        __meta_FileDescriptorProto[] = target = ProtoMeta(FileDescriptorProto)
+        fnum = Int[1,2,3,10,11,4,5,6,7,8,9,12]
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :package => AbstractString, :dependency => Base.Vector{AbstractString}, :public_dependency => Base.Vector{Int32}, :weak_dependency => Base.Vector{Int32}, :message_type => Base.Vector{DescriptorProto}, :enum_type => Base.Vector{EnumDescriptorProto}, :service => Base.Vector{ServiceDescriptorProto}, :extension => Base.Vector{FieldDescriptorProto}, :options => FileOptions, :source_code_info => SourceCodeInfo, :syntax => AbstractString]
+        meta(target, FileDescriptorProto, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_FileDescriptorProto[]
+end
+function Base.getproperty(obj::FileDescriptorProto, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :package
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :dependency
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{AbstractString}
+    elseif name === :public_dependency
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Int32}
+    elseif name === :weak_dependency
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Int32}
+    elseif name === :message_type
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{DescriptorProto}
+    elseif name === :enum_type
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{EnumDescriptorProto}
+    elseif name === :service
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{ServiceDescriptorProto}
+    elseif name === :extension
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{FieldDescriptorProto}
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::FileOptions
+    elseif name === :source_code_info
+        return (obj.__protobuf_jl_internal_values[name])::SourceCodeInfo
+    elseif name === :syntax
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct FileDescriptorSet <: ProtoType
-    file::Base.Vector{FileDescriptorProto}
-    FileDescriptorSet(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct FileDescriptorSet
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function FileDescriptorSet(; kwargs...)
+        obj = new(meta(FileDescriptorSet), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct FileDescriptorSet
+const __meta_FileDescriptorSet = Ref{ProtoMeta}()
+function meta(::Type{FileDescriptorSet})
+    if !isassigned(__meta_FileDescriptorSet)
+        __meta_FileDescriptorSet[] = target = ProtoMeta(FileDescriptorSet)
+        allflds = Pair{Symbol,Union{Type,String}}[:file => Base.Vector{FileDescriptorProto}]
+        meta(target, FileDescriptorSet, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_FileDescriptorSet[]
+end
+function Base.getproperty(obj::FileDescriptorSet, name::Symbol)
+    if name === :file
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{FileDescriptorProto}
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct GeneratedCodeInfo_Annotation <: ProtoType
-    path::Base.Vector{Int32}
-    source_file::AbstractString
-    _begin::Int32
-    _end::Int32
-    GeneratedCodeInfo_Annotation(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct GeneratedCodeInfo_Annotation
-const __pack_GeneratedCodeInfo_Annotation = Symbol[:path]
-meta(t::Type{GeneratedCodeInfo_Annotation}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, __pack_GeneratedCodeInfo_Annotation, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function GeneratedCodeInfo_Annotation(; kwargs...)
+        obj = new(meta(GeneratedCodeInfo_Annotation), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct GeneratedCodeInfo_Annotation
+const __meta_GeneratedCodeInfo_Annotation = Ref{ProtoMeta}()
+function meta(::Type{GeneratedCodeInfo_Annotation})
+    if !isassigned(__meta_GeneratedCodeInfo_Annotation)
+        __meta_GeneratedCodeInfo_Annotation[] = target = ProtoMeta(GeneratedCodeInfo_Annotation)
+        pack = Symbol[:path]
+        allflds = Pair{Symbol,Union{Type,String}}[:path => Base.Vector{Int32}, :source_file => AbstractString, :_begin => Int32, :_end => Int32]
+        meta(target, GeneratedCodeInfo_Annotation, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, pack, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_GeneratedCodeInfo_Annotation[]
+end
+function Base.getproperty(obj::GeneratedCodeInfo_Annotation, name::Symbol)
+    if name === :path
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Int32}
+    elseif name === :source_file
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :_begin
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :_end
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct GeneratedCodeInfo <: ProtoType
-    annotation::Base.Vector{GeneratedCodeInfo_Annotation}
-    GeneratedCodeInfo(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct GeneratedCodeInfo
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function GeneratedCodeInfo(; kwargs...)
+        obj = new(meta(GeneratedCodeInfo), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct GeneratedCodeInfo
+const __meta_GeneratedCodeInfo = Ref{ProtoMeta}()
+function meta(::Type{GeneratedCodeInfo})
+    if !isassigned(__meta_GeneratedCodeInfo)
+        __meta_GeneratedCodeInfo[] = target = ProtoMeta(GeneratedCodeInfo)
+        allflds = Pair{Symbol,Union{Type,String}}[:annotation => Base.Vector{GeneratedCodeInfo_Annotation}]
+        meta(target, GeneratedCodeInfo, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_GeneratedCodeInfo[]
+end
+function Base.getproperty(obj::GeneratedCodeInfo, name::Symbol)
+    if name === :annotation
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{GeneratedCodeInfo_Annotation}
+    else
+        getfield(obj, name)
+    end
+end
 
 export FileDescriptorSet, FileDescriptorProto, DescriptorProto_ExtensionRange, DescriptorProto_ReservedRange, DescriptorProto, ExtensionRangeOptions, FieldDescriptorProto_Type, FieldDescriptorProto_Label, FieldDescriptorProto, OneofDescriptorProto, EnumDescriptorProto_EnumReservedRange, EnumDescriptorProto, EnumValueDescriptorProto, ServiceDescriptorProto, MethodDescriptorProto, FileOptions_OptimizeMode, FileOptions, MessageOptions, FieldOptions_CType, FieldOptions_JSType, FieldOptions, OneofOptions, EnumOptions, EnumValueOptions, ServiceOptions, MethodOptions_IdempotencyLevel, MethodOptions, UninterpretedOption_NamePart, UninterpretedOption, SourceCodeInfo_Location, SourceCodeInfo, GeneratedCodeInfo_Annotation, GeneratedCodeInfo

--- a/src/google/duration_pb.jl
+++ b/src/google/duration_pb.jl
@@ -1,8 +1,38 @@
 # syntax: proto3
 mutable struct Duration <: ProtoType
-    seconds::Int64
-    nanos::Int32
-    Duration(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Duration
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Duration(; kwargs...)
+        obj = new(meta(Duration), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Duration
+const __meta_Duration = Ref{ProtoMeta}()
+function meta(::Type{Duration})
+    if !isassigned(__meta_Duration)
+        __meta_Duration[] = target = ProtoMeta(Duration)
+        allflds = Pair{Symbol,Union{Type,String}}[:seconds => Int64, :nanos => Int32]
+        meta(target, Duration, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Duration[]
+end
+function Base.getproperty(obj::Duration, name::Symbol)
+    if name === :seconds
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :nanos
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 export Duration

--- a/src/google/duration_pb.jl
+++ b/src/google/duration_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct Duration <: ProtoType
     seconds::Int64
     nanos::Int32

--- a/src/google/duration_pb.jl
+++ b/src/google/duration_pb.jl
@@ -18,12 +18,14 @@ mutable struct Duration <: ProtoType
 end # mutable struct Duration
 const __meta_Duration = Ref{ProtoMeta}()
 function meta(::Type{Duration})
-    if !isassigned(__meta_Duration)
-        __meta_Duration[] = target = ProtoMeta(Duration)
-        allflds = Pair{Symbol,Union{Type,String}}[:seconds => Int64, :nanos => Int32]
-        meta(target, Duration, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Duration)
+            __meta_Duration[] = target = ProtoMeta(Duration)
+            allflds = Pair{Symbol,Union{Type,String}}[:seconds => Int64, :nanos => Int32]
+            meta(target, Duration, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Duration[]
     end
-    __meta_Duration[]
 end
 function Base.getproperty(obj::Duration, name::Symbol)
     if name === :seconds

--- a/src/google/empty_pb.jl
+++ b/src/google/empty_pb.jl
@@ -18,12 +18,14 @@ mutable struct Empty <: ProtoType
 end # mutable struct Empty
 const __meta_Empty = Ref{ProtoMeta}()
 function meta(::Type{Empty})
-    if !isassigned(__meta_Empty)
-        __meta_Empty[] = target = ProtoMeta(Empty)
-        allflds = Pair{Symbol,Union{Type,String}}[]
-        meta(target, Empty, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Empty)
+            __meta_Empty[] = target = ProtoMeta(Empty)
+            allflds = Pair{Symbol,Union{Type,String}}[]
+            meta(target, Empty, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Empty[]
     end
-    __meta_Empty[]
 end
 
 export Empty

--- a/src/google/empty_pb.jl
+++ b/src/google/empty_pb.jl
@@ -1,6 +1,29 @@
 # syntax: proto3
 mutable struct Empty <: ProtoType
-    Empty(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Empty
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Empty(; kwargs...)
+        obj = new(meta(Empty), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Empty
+const __meta_Empty = Ref{ProtoMeta}()
+function meta(::Type{Empty})
+    if !isassigned(__meta_Empty)
+        __meta_Empty[] = target = ProtoMeta(Empty)
+        allflds = Pair{Symbol,Union{Type,String}}[]
+        meta(target, Empty, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Empty[]
+end
 
 export Empty

--- a/src/google/empty_pb.jl
+++ b/src/google/empty_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct Empty <: ProtoType
     Empty(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
 end #mutable struct Empty

--- a/src/google/field_mask_pb.jl
+++ b/src/google/field_mask_pb.jl
@@ -18,12 +18,14 @@ mutable struct FieldMask <: ProtoType
 end # mutable struct FieldMask
 const __meta_FieldMask = Ref{ProtoMeta}()
 function meta(::Type{FieldMask})
-    if !isassigned(__meta_FieldMask)
-        __meta_FieldMask[] = target = ProtoMeta(FieldMask)
-        allflds = Pair{Symbol,Union{Type,String}}[:paths => Base.Vector{AbstractString}]
-        meta(target, FieldMask, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_FieldMask)
+            __meta_FieldMask[] = target = ProtoMeta(FieldMask)
+            allflds = Pair{Symbol,Union{Type,String}}[:paths => Base.Vector{AbstractString}]
+            meta(target, FieldMask, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_FieldMask[]
     end
-    __meta_FieldMask[]
 end
 function Base.getproperty(obj::FieldMask, name::Symbol)
     if name === :paths

--- a/src/google/field_mask_pb.jl
+++ b/src/google/field_mask_pb.jl
@@ -1,7 +1,36 @@
 # syntax: proto3
 mutable struct FieldMask <: ProtoType
-    paths::Base.Vector{AbstractString}
-    FieldMask(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct FieldMask
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function FieldMask(; kwargs...)
+        obj = new(meta(FieldMask), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct FieldMask
+const __meta_FieldMask = Ref{ProtoMeta}()
+function meta(::Type{FieldMask})
+    if !isassigned(__meta_FieldMask)
+        __meta_FieldMask[] = target = ProtoMeta(FieldMask)
+        allflds = Pair{Symbol,Union{Type,String}}[:paths => Base.Vector{AbstractString}]
+        meta(target, FieldMask, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_FieldMask[]
+end
+function Base.getproperty(obj::FieldMask, name::Symbol)
+    if name === :paths
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{AbstractString}
+    else
+        getfield(obj, name)
+    end
+end
 
 export FieldMask

--- a/src/google/field_mask_pb.jl
+++ b/src/google/field_mask_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct FieldMask <: ProtoType
     paths::Base.Vector{AbstractString}
     FieldMask(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)

--- a/src/google/google.jl
+++ b/src/google/google.jl
@@ -1,6 +1,10 @@
 module GoogleProtoBuf
+    using ..ProtoBuf
+    import ..ProtoBuf: meta
     include("descriptor_pb.jl")
 end
 module GoogleProtoBufCompiler
+    using ..ProtoBuf
+    import ..ProtoBuf: meta
     include("plugin_pb.jl")
 end

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto2
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct Version <: ProtoType
     major::Int32
     minor::Int32

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -1,37 +1,159 @@
 # syntax: proto2
 mutable struct Version <: ProtoType
-    major::Int32
-    minor::Int32
-    patch::Int32
-    suffix::AbstractString
-    Version(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Version
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Version(; kwargs...)
+        obj = new(meta(Version), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Version
+const __meta_Version = Ref{ProtoMeta}()
+function meta(::Type{Version})
+    if !isassigned(__meta_Version)
+        __meta_Version[] = target = ProtoMeta(Version)
+        allflds = Pair{Symbol,Union{Type,String}}[:major => Int32, :minor => Int32, :patch => Int32, :suffix => AbstractString]
+        meta(target, Version, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Version[]
+end
+function Base.getproperty(obj::Version, name::Symbol)
+    if name === :major
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :minor
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :patch
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :suffix
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct CodeGeneratorRequest <: ProtoType
-    file_to_generate::Base.Vector{AbstractString}
-    parameter::AbstractString
-    proto_file::Base.Vector{ProtoBuf.GoogleProtoBuf.FileDescriptorProto}
-    compiler_version::Version
-    CodeGeneratorRequest(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct CodeGeneratorRequest
-const __fnum_CodeGeneratorRequest = Int[1,2,15,3]
-meta(t::Type{CodeGeneratorRequest}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorRequest, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function CodeGeneratorRequest(; kwargs...)
+        obj = new(meta(CodeGeneratorRequest), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct CodeGeneratorRequest
+const __meta_CodeGeneratorRequest = Ref{ProtoMeta}()
+function meta(::Type{CodeGeneratorRequest})
+    if !isassigned(__meta_CodeGeneratorRequest)
+        __meta_CodeGeneratorRequest[] = target = ProtoMeta(CodeGeneratorRequest)
+        fnum = Int[1,2,15,3]
+        allflds = Pair{Symbol,Union{Type,String}}[:file_to_generate => Base.Vector{AbstractString}, :parameter => AbstractString, :proto_file => Base.Vector{ProtoBuf.GoogleProtoBuf.FileDescriptorProto}, :compiler_version => Version]
+        meta(target, CodeGeneratorRequest, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_CodeGeneratorRequest[]
+end
+function Base.getproperty(obj::CodeGeneratorRequest, name::Symbol)
+    if name === :file_to_generate
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{AbstractString}
+    elseif name === :parameter
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :proto_file
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{ProtoBuf.GoogleProtoBuf.FileDescriptorProto}
+    elseif name === :compiler_version
+        return (obj.__protobuf_jl_internal_values[name])::Version
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct CodeGeneratorResponse_File <: ProtoType
-    name::AbstractString
-    insertion_point::AbstractString
-    content::AbstractString
-    CodeGeneratorResponse_File(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct CodeGeneratorResponse_File
-const __fnum_CodeGeneratorResponse_File = Int[1,2,15]
-meta(t::Type{CodeGeneratorResponse_File}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorResponse_File, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function CodeGeneratorResponse_File(; kwargs...)
+        obj = new(meta(CodeGeneratorResponse_File), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct CodeGeneratorResponse_File
+const __meta_CodeGeneratorResponse_File = Ref{ProtoMeta}()
+function meta(::Type{CodeGeneratorResponse_File})
+    if !isassigned(__meta_CodeGeneratorResponse_File)
+        __meta_CodeGeneratorResponse_File[] = target = ProtoMeta(CodeGeneratorResponse_File)
+        fnum = Int[1,2,15]
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :insertion_point => AbstractString, :content => AbstractString]
+        meta(target, CodeGeneratorResponse_File, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_CodeGeneratorResponse_File[]
+end
+function Base.getproperty(obj::CodeGeneratorResponse_File, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :insertion_point
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :content
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct CodeGeneratorResponse <: ProtoType
-    error::AbstractString
-    file::Base.Vector{CodeGeneratorResponse_File}
-    CodeGeneratorResponse(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct CodeGeneratorResponse
-const __fnum_CodeGeneratorResponse = Int[1,15]
-meta(t::Type{CodeGeneratorResponse}) = meta(t, ProtoBuf.DEF_REQ, __fnum_CodeGeneratorResponse, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function CodeGeneratorResponse(; kwargs...)
+        obj = new(meta(CodeGeneratorResponse), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct CodeGeneratorResponse
+const __meta_CodeGeneratorResponse = Ref{ProtoMeta}()
+function meta(::Type{CodeGeneratorResponse})
+    if !isassigned(__meta_CodeGeneratorResponse)
+        __meta_CodeGeneratorResponse[] = target = ProtoMeta(CodeGeneratorResponse)
+        fnum = Int[1,15]
+        allflds = Pair{Symbol,Union{Type,String}}[:error => AbstractString, :file => Base.Vector{CodeGeneratorResponse_File}]
+        meta(target, CodeGeneratorResponse, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_CodeGeneratorResponse[]
+end
+function Base.getproperty(obj::CodeGeneratorResponse, name::Symbol)
+    if name === :error
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :file
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{CodeGeneratorResponse_File}
+    else
+        getfield(obj, name)
+    end
+end
 
 export Version, CodeGeneratorRequest, CodeGeneratorResponse_File, CodeGeneratorResponse

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -18,12 +18,14 @@ mutable struct Version <: ProtoType
 end # mutable struct Version
 const __meta_Version = Ref{ProtoMeta}()
 function meta(::Type{Version})
-    if !isassigned(__meta_Version)
-        __meta_Version[] = target = ProtoMeta(Version)
-        allflds = Pair{Symbol,Union{Type,String}}[:major => Int32, :minor => Int32, :patch => Int32, :suffix => AbstractString]
-        meta(target, Version, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Version)
+            __meta_Version[] = target = ProtoMeta(Version)
+            allflds = Pair{Symbol,Union{Type,String}}[:major => Int32, :minor => Int32, :patch => Int32, :suffix => AbstractString]
+            meta(target, Version, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Version[]
     end
-    __meta_Version[]
 end
 function Base.getproperty(obj::Version, name::Symbol)
     if name === :major
@@ -58,13 +60,15 @@ mutable struct CodeGeneratorRequest <: ProtoType
 end # mutable struct CodeGeneratorRequest
 const __meta_CodeGeneratorRequest = Ref{ProtoMeta}()
 function meta(::Type{CodeGeneratorRequest})
-    if !isassigned(__meta_CodeGeneratorRequest)
-        __meta_CodeGeneratorRequest[] = target = ProtoMeta(CodeGeneratorRequest)
-        fnum = Int[1,2,15,3]
-        allflds = Pair{Symbol,Union{Type,String}}[:file_to_generate => Base.Vector{AbstractString}, :parameter => AbstractString, :proto_file => Base.Vector{ProtoBuf.GoogleProtoBuf.FileDescriptorProto}, :compiler_version => Version]
-        meta(target, CodeGeneratorRequest, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_CodeGeneratorRequest)
+            __meta_CodeGeneratorRequest[] = target = ProtoMeta(CodeGeneratorRequest)
+            fnum = Int[1,2,15,3]
+            allflds = Pair{Symbol,Union{Type,String}}[:file_to_generate => Base.Vector{AbstractString}, :parameter => AbstractString, :proto_file => Base.Vector{ProtoBuf.GoogleProtoBuf.FileDescriptorProto}, :compiler_version => Version]
+            meta(target, CodeGeneratorRequest, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_CodeGeneratorRequest[]
     end
-    __meta_CodeGeneratorRequest[]
 end
 function Base.getproperty(obj::CodeGeneratorRequest, name::Symbol)
     if name === :file_to_generate
@@ -99,13 +103,15 @@ mutable struct CodeGeneratorResponse_File <: ProtoType
 end # mutable struct CodeGeneratorResponse_File
 const __meta_CodeGeneratorResponse_File = Ref{ProtoMeta}()
 function meta(::Type{CodeGeneratorResponse_File})
-    if !isassigned(__meta_CodeGeneratorResponse_File)
-        __meta_CodeGeneratorResponse_File[] = target = ProtoMeta(CodeGeneratorResponse_File)
-        fnum = Int[1,2,15]
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :insertion_point => AbstractString, :content => AbstractString]
-        meta(target, CodeGeneratorResponse_File, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_CodeGeneratorResponse_File)
+            __meta_CodeGeneratorResponse_File[] = target = ProtoMeta(CodeGeneratorResponse_File)
+            fnum = Int[1,2,15]
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :insertion_point => AbstractString, :content => AbstractString]
+            meta(target, CodeGeneratorResponse_File, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_CodeGeneratorResponse_File[]
     end
-    __meta_CodeGeneratorResponse_File[]
 end
 function Base.getproperty(obj::CodeGeneratorResponse_File, name::Symbol)
     if name === :name
@@ -138,13 +144,15 @@ mutable struct CodeGeneratorResponse <: ProtoType
 end # mutable struct CodeGeneratorResponse
 const __meta_CodeGeneratorResponse = Ref{ProtoMeta}()
 function meta(::Type{CodeGeneratorResponse})
-    if !isassigned(__meta_CodeGeneratorResponse)
-        __meta_CodeGeneratorResponse[] = target = ProtoMeta(CodeGeneratorResponse)
-        fnum = Int[1,15]
-        allflds = Pair{Symbol,Union{Type,String}}[:error => AbstractString, :file => Base.Vector{CodeGeneratorResponse_File}]
-        meta(target, CodeGeneratorResponse, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_CodeGeneratorResponse)
+            __meta_CodeGeneratorResponse[] = target = ProtoMeta(CodeGeneratorResponse)
+            fnum = Int[1,15]
+            allflds = Pair{Symbol,Union{Type,String}}[:error => AbstractString, :file => Base.Vector{CodeGeneratorResponse_File}]
+            meta(target, CodeGeneratorResponse, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_CodeGeneratorResponse[]
     end
-    __meta_CodeGeneratorResponse[]
 end
 function Base.getproperty(obj::CodeGeneratorResponse, name::Symbol)
     if name === :error

--- a/src/google/source_context_pb.jl
+++ b/src/google/source_context_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct SourceContext <: ProtoType
     file_name::AbstractString
     SourceContext(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)

--- a/src/google/source_context_pb.jl
+++ b/src/google/source_context_pb.jl
@@ -1,7 +1,36 @@
 # syntax: proto3
 mutable struct SourceContext <: ProtoType
-    file_name::AbstractString
-    SourceContext(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct SourceContext
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function SourceContext(; kwargs...)
+        obj = new(meta(SourceContext), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct SourceContext
+const __meta_SourceContext = Ref{ProtoMeta}()
+function meta(::Type{SourceContext})
+    if !isassigned(__meta_SourceContext)
+        __meta_SourceContext[] = target = ProtoMeta(SourceContext)
+        allflds = Pair{Symbol,Union{Type,String}}[:file_name => AbstractString]
+        meta(target, SourceContext, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_SourceContext[]
+end
+function Base.getproperty(obj::SourceContext, name::Symbol)
+    if name === :file_name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 export SourceContext

--- a/src/google/source_context_pb.jl
+++ b/src/google/source_context_pb.jl
@@ -18,12 +18,14 @@ mutable struct SourceContext <: ProtoType
 end # mutable struct SourceContext
 const __meta_SourceContext = Ref{ProtoMeta}()
 function meta(::Type{SourceContext})
-    if !isassigned(__meta_SourceContext)
-        __meta_SourceContext[] = target = ProtoMeta(SourceContext)
-        allflds = Pair{Symbol,Union{Type,String}}[:file_name => AbstractString]
-        meta(target, SourceContext, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_SourceContext)
+            __meta_SourceContext[] = target = ProtoMeta(SourceContext)
+            allflds = Pair{Symbol,Union{Type,String}}[:file_name => AbstractString]
+            meta(target, SourceContext, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_SourceContext[]
     end
-    __meta_SourceContext[]
 end
 function Base.getproperty(obj::SourceContext, name::Symbol)
     if name === :file_name

--- a/src/google/struct_pb.jl
+++ b/src/google/struct_pb.jl
@@ -22,12 +22,14 @@ mutable struct Struct_FieldsEntry <: ProtoType
 end # mutable struct Struct_FieldsEntry (mapentry) (has cyclic type dependency)
 const __meta_Struct_FieldsEntry = Ref{ProtoMeta}()
 function meta(::Type{Struct_FieldsEntry})
-    if !isassigned(__meta_Struct_FieldsEntry)
-        __meta_Struct_FieldsEntry[] = target = ProtoMeta(Struct_FieldsEntry)
-        allflds = Pair{Symbol,Union{Type,String}}[:key => AbstractString, :value => "Value"]
-        meta(target, Struct_FieldsEntry, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Struct_FieldsEntry)
+            __meta_Struct_FieldsEntry[] = target = ProtoMeta(Struct_FieldsEntry)
+            allflds = Pair{Symbol,Union{Type,String}}[:key => AbstractString, :value => "Value"]
+            meta(target, Struct_FieldsEntry, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Struct_FieldsEntry[]
     end
-    __meta_Struct_FieldsEntry[]
 end
 function Base.getproperty(obj::Struct_FieldsEntry, name::Symbol)
     if name === :key
@@ -58,12 +60,14 @@ mutable struct Struct <: ProtoType
 end # mutable struct Struct (has cyclic type dependency)
 const __meta_Struct = Ref{ProtoMeta}()
 function meta(::Type{Struct})
-    if !isassigned(__meta_Struct)
-        __meta_Struct[] = target = ProtoMeta(Struct)
-        allflds = Pair{Symbol,Union{Type,String}}[:fields => "Base.Dict{AbstractString,Value}"]
-        meta(target, Struct, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Struct)
+            __meta_Struct[] = target = ProtoMeta(Struct)
+            allflds = Pair{Symbol,Union{Type,String}}[:fields => "Base.Dict{AbstractString,Value}"]
+            meta(target, Struct, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Struct[]
     end
-    __meta_Struct[]
 end
 function Base.getproperty(obj::Struct, name::Symbol)
     if name === :fields
@@ -92,14 +96,16 @@ mutable struct Value <: ProtoType
 end # mutable struct Value (has cyclic type dependency)
 const __meta_Value = Ref{ProtoMeta}()
 function meta(::Type{Value})
-    if !isassigned(__meta_Value)
-        __meta_Value[] = target = ProtoMeta(Value)
-        allflds = Pair{Symbol,Union{Type,String}}[:null_value => Int32, :number_value => Float64, :string_value => AbstractString, :bool_value => Bool, :struct_value => Struct, :list_value => "ListValue"]
-        oneofs = Int[1,1,1,1,1,1]
-        oneof_names = Symbol[Symbol("kind")]
-        meta(target, Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, oneofs, oneof_names)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Value)
+            __meta_Value[] = target = ProtoMeta(Value)
+            allflds = Pair{Symbol,Union{Type,String}}[:null_value => Int32, :number_value => Float64, :string_value => AbstractString, :bool_value => Bool, :struct_value => Struct, :list_value => "ListValue"]
+            oneofs = Int[1,1,1,1,1,1]
+            oneof_names = Symbol[Symbol("kind")]
+            meta(target, Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, oneofs, oneof_names)
+        end
+        __meta_Value[]
     end
-    __meta_Value[]
 end
 function Base.getproperty(obj::Value, name::Symbol)
     if name === :null_value
@@ -138,12 +144,14 @@ mutable struct ListValue <: ProtoType
 end # mutable struct ListValue (has cyclic type dependency)
 const __meta_ListValue = Ref{ProtoMeta}()
 function meta(::Type{ListValue})
-    if !isassigned(__meta_ListValue)
-        __meta_ListValue[] = target = ProtoMeta(ListValue)
-        allflds = Pair{Symbol,Union{Type,String}}[:values => Base.Vector{Value}]
-        meta(target, ListValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_ListValue)
+            __meta_ListValue[] = target = ProtoMeta(ListValue)
+            allflds = Pair{Symbol,Union{Type,String}}[:values => Base.Vector{Value}]
+            meta(target, ListValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_ListValue[]
     end
-    __meta_ListValue[]
 end
 function Base.getproperty(obj::ListValue, name::Symbol)
     if name === :values

--- a/src/google/struct_pb.jl
+++ b/src/google/struct_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 struct __enum_NullValue <: ProtoEnum
     NULL_VALUE::Int32
     __enum_NullValue() = new(0)

--- a/src/google/struct_pb.jl
+++ b/src/google/struct_pb.jl
@@ -1,43 +1,157 @@
 # syntax: proto3
-struct __enum_NullValue <: ProtoEnum
-    NULL_VALUE::Int32
-    __enum_NullValue() = new(0)
-end #struct __enum_NullValue
-const NullValue = __enum_NullValue()
+const NullValue = (;[
+    Symbol("NULL_VALUE") => Int32(0),
+]...)
 
 mutable struct Struct_FieldsEntry <: ProtoType
-    key::AbstractString
-    value::Base.Any
-    Struct_FieldsEntry(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Struct_FieldsEntry (mapentry) (has cyclic type dependency)
-const __ftype_Struct_FieldsEntry = Dict(:value => "Value")
-meta(t::Type{Struct_FieldsEntry}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, __ftype_Struct_FieldsEntry)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Struct_FieldsEntry(; kwargs...)
+        obj = new(meta(Struct_FieldsEntry), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Struct_FieldsEntry (mapentry) (has cyclic type dependency)
+const __meta_Struct_FieldsEntry = Ref{ProtoMeta}()
+function meta(::Type{Struct_FieldsEntry})
+    if !isassigned(__meta_Struct_FieldsEntry)
+        __meta_Struct_FieldsEntry[] = target = ProtoMeta(Struct_FieldsEntry)
+        allflds = Pair{Symbol,Union{Type,String}}[:key => AbstractString, :value => "Value"]
+        meta(target, Struct_FieldsEntry, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Struct_FieldsEntry[]
+end
+function Base.getproperty(obj::Struct_FieldsEntry, name::Symbol)
+    if name === :key
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Any
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct Struct <: ProtoType
-    fields::Base.Dict # map entry
-    Struct(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Struct (has cyclic type dependency)
-const __ftype_Struct = Dict(:fields => "Base.Dict{AbstractString,Value}")
-meta(t::Type{Struct}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, __ftype_Struct)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Struct(; kwargs...)
+        obj = new(meta(Struct), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Struct (has cyclic type dependency)
+const __meta_Struct = Ref{ProtoMeta}()
+function meta(::Type{Struct})
+    if !isassigned(__meta_Struct)
+        __meta_Struct[] = target = ProtoMeta(Struct)
+        allflds = Pair{Symbol,Union{Type,String}}[:fields => "Base.Dict{AbstractString,Value}"]
+        meta(target, Struct, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Struct[]
+end
+function Base.getproperty(obj::Struct, name::Symbol)
+    if name === :fields
+        return (obj.__protobuf_jl_internal_values[name])::Any
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct Value <: ProtoType
-    null_value::Int32
-    number_value::Float64
-    string_value::AbstractString
-    bool_value::Bool
-    struct_value::Struct
-    list_value::Base.Any
-    Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Value (has cyclic type dependency)
-const __ftype_Value = Dict(:list_value => "ListValue")
-const __oneofs_Value = Int[1,1,1,1,1,1]
-const __oneof_names_Value = [Symbol("kind")]
-meta(t::Type{Value}) = meta(t, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, __oneofs_Value, __oneof_names_Value, __ftype_Value)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Value(; kwargs...)
+        obj = new(meta(Value), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Value (has cyclic type dependency)
+const __meta_Value = Ref{ProtoMeta}()
+function meta(::Type{Value})
+    if !isassigned(__meta_Value)
+        __meta_Value[] = target = ProtoMeta(Value)
+        allflds = Pair{Symbol,Union{Type,String}}[:null_value => Int32, :number_value => Float64, :string_value => AbstractString, :bool_value => Bool, :struct_value => Struct, :list_value => "ListValue"]
+        oneofs = Int[1,1,1,1,1,1]
+        oneof_names = Symbol[Symbol("kind")]
+        meta(target, Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, oneofs, oneof_names)
+    end
+    __meta_Value[]
+end
+function Base.getproperty(obj::Value, name::Symbol)
+    if name === :null_value
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :number_value
+        return (obj.__protobuf_jl_internal_values[name])::Float64
+    elseif name === :string_value
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :bool_value
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :struct_value
+        return (obj.__protobuf_jl_internal_values[name])::Struct
+    elseif name === :list_value
+        return (obj.__protobuf_jl_internal_values[name])::Any
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct ListValue <: ProtoType
-    values::Base.Vector{Value}
-    ListValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct ListValue (has cyclic type dependency)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function ListValue(; kwargs...)
+        obj = new(meta(ListValue), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct ListValue (has cyclic type dependency)
+const __meta_ListValue = Ref{ProtoMeta}()
+function meta(::Type{ListValue})
+    if !isassigned(__meta_ListValue)
+        __meta_ListValue[] = target = ProtoMeta(ListValue)
+        allflds = Pair{Symbol,Union{Type,String}}[:values => Base.Vector{Value}]
+        meta(target, ListValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_ListValue[]
+end
+function Base.getproperty(obj::ListValue, name::Symbol)
+    if name === :values
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Value}
+    else
+        getfield(obj, name)
+    end
+end
 
 export NullValue, Struct_FieldsEntry, Struct, Value, ListValue, Struct_FieldsEntry, Struct, Value, ListValue
-# mapentries: "Struct_FieldsEntry"=>("AbstractString", "Value")
+# mapentries: "Struct_FieldsEntry" => ("AbstractString", "Value")

--- a/src/google/timestamp_pb.jl
+++ b/src/google/timestamp_pb.jl
@@ -1,8 +1,38 @@
 # syntax: proto3
 mutable struct Timestamp <: ProtoType
-    seconds::Int64
-    nanos::Int32
-    Timestamp(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Timestamp
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Timestamp(; kwargs...)
+        obj = new(meta(Timestamp), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Timestamp
+const __meta_Timestamp = Ref{ProtoMeta}()
+function meta(::Type{Timestamp})
+    if !isassigned(__meta_Timestamp)
+        __meta_Timestamp[] = target = ProtoMeta(Timestamp)
+        allflds = Pair{Symbol,Union{Type,String}}[:seconds => Int64, :nanos => Int32]
+        meta(target, Timestamp, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Timestamp[]
+end
+function Base.getproperty(obj::Timestamp, name::Symbol)
+    if name === :seconds
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :nanos
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 export Timestamp

--- a/src/google/timestamp_pb.jl
+++ b/src/google/timestamp_pb.jl
@@ -18,12 +18,14 @@ mutable struct Timestamp <: ProtoType
 end # mutable struct Timestamp
 const __meta_Timestamp = Ref{ProtoMeta}()
 function meta(::Type{Timestamp})
-    if !isassigned(__meta_Timestamp)
-        __meta_Timestamp[] = target = ProtoMeta(Timestamp)
-        allflds = Pair{Symbol,Union{Type,String}}[:seconds => Int64, :nanos => Int32]
-        meta(target, Timestamp, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Timestamp)
+            __meta_Timestamp[] = target = ProtoMeta(Timestamp)
+            allflds = Pair{Symbol,Union{Type,String}}[:seconds => Int64, :nanos => Int32]
+            meta(target, Timestamp, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Timestamp[]
     end
-    __meta_Timestamp[]
 end
 function Base.getproperty(obj::Timestamp, name::Symbol)
     if name === :seconds

--- a/src/google/timestamp_pb.jl
+++ b/src/google/timestamp_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct Timestamp <: ProtoType
     seconds::Int64
     nanos::Int32

--- a/src/google/type_pb.jl
+++ b/src/google/type_pb.jl
@@ -23,12 +23,14 @@ mutable struct Option <: ProtoType
 end # mutable struct Option
 const __meta_Option = Ref{ProtoMeta}()
 function meta(::Type{Option})
-    if !isassigned(__meta_Option)
-        __meta_Option[] = target = ProtoMeta(Option)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :value => _Any]
-        meta(target, Option, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Option)
+            __meta_Option[] = target = ProtoMeta(Option)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :value => _Any]
+            meta(target, Option, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Option[]
     end
-    __meta_Option[]
 end
 function Base.getproperty(obj::Option, name::Symbol)
     if name === :name
@@ -59,12 +61,14 @@ mutable struct EnumValue <: ProtoType
 end # mutable struct EnumValue
 const __meta_EnumValue = Ref{ProtoMeta}()
 function meta(::Type{EnumValue})
-    if !isassigned(__meta_EnumValue)
-        __meta_EnumValue[] = target = ProtoMeta(EnumValue)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :options => Base.Vector{Option}]
-        meta(target, EnumValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_EnumValue)
+            __meta_EnumValue[] = target = ProtoMeta(EnumValue)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :options => Base.Vector{Option}]
+            meta(target, EnumValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_EnumValue[]
     end
-    __meta_EnumValue[]
 end
 function Base.getproperty(obj::EnumValue, name::Symbol)
     if name === :name
@@ -126,13 +130,15 @@ mutable struct Field <: ProtoType
 end # mutable struct Field
 const __meta_Field = Ref{ProtoMeta}()
 function meta(::Type{Field})
-    if !isassigned(__meta_Field)
-        __meta_Field[] = target = ProtoMeta(Field)
-        fnum = Int[1,2,3,4,6,7,8,9,10,11]
-        allflds = Pair{Symbol,Union{Type,String}}[:kind => Int32, :cardinality => Int32, :number => Int32, :name => AbstractString, :type_url => AbstractString, :oneof_index => Int32, :packed => Bool, :options => Base.Vector{Option}, :json_name => AbstractString, :default_value => AbstractString]
-        meta(target, Field, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Field)
+            __meta_Field[] = target = ProtoMeta(Field)
+            fnum = Int[1,2,3,4,6,7,8,9,10,11]
+            allflds = Pair{Symbol,Union{Type,String}}[:kind => Int32, :cardinality => Int32, :number => Int32, :name => AbstractString, :type_url => AbstractString, :oneof_index => Int32, :packed => Bool, :options => Base.Vector{Option}, :json_name => AbstractString, :default_value => AbstractString]
+            meta(target, Field, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Field[]
     end
-    __meta_Field[]
 end
 function Base.getproperty(obj::Field, name::Symbol)
     if name === :kind
@@ -179,12 +185,14 @@ mutable struct _Enum <: ProtoType
 end # mutable struct _Enum
 const __meta__Enum = Ref{ProtoMeta}()
 function meta(::Type{_Enum})
-    if !isassigned(__meta__Enum)
-        __meta__Enum[] = target = ProtoMeta(_Enum)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :enumvalue => Base.Vector{EnumValue}, :options => Base.Vector{Option}, :source_context => SourceContext, :syntax => Int32]
-        meta(target, _Enum, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta__Enum)
+            __meta__Enum[] = target = ProtoMeta(_Enum)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :enumvalue => Base.Vector{EnumValue}, :options => Base.Vector{Option}, :source_context => SourceContext, :syntax => Int32]
+            meta(target, _Enum, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta__Enum[]
     end
-    __meta__Enum[]
 end
 function Base.getproperty(obj::_Enum, name::Symbol)
     if name === :name
@@ -221,12 +229,14 @@ mutable struct _Type <: ProtoType
 end # mutable struct _Type
 const __meta__Type = Ref{ProtoMeta}()
 function meta(::Type{_Type})
-    if !isassigned(__meta__Type)
-        __meta__Type[] = target = ProtoMeta(_Type)
-        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :fields => Base.Vector{Field}, :oneofs => Base.Vector{AbstractString}, :options => Base.Vector{Option}, :source_context => SourceContext, :syntax => Int32]
-        meta(target, _Type, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta__Type)
+            __meta__Type[] = target = ProtoMeta(_Type)
+            allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :fields => Base.Vector{Field}, :oneofs => Base.Vector{AbstractString}, :options => Base.Vector{Option}, :source_context => SourceContext, :syntax => Int32]
+            meta(target, _Type, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta__Type[]
     end
-    __meta__Type[]
 end
 function Base.getproperty(obj::_Type, name::Symbol)
     if name === :name

--- a/src/google/type_pb.jl
+++ b/src/google/type_pb.jl
@@ -1,90 +1,249 @@
 # syntax: proto3
-struct __enum_Syntax <: ProtoEnum
-    SYNTAX_PROTO2::Int32
-    SYNTAX_PROTO3::Int32
-    __enum_Syntax() = new(0,1)
-end #struct __enum_Syntax
-const Syntax = __enum_Syntax()
+const Syntax = (;[
+    Symbol("SYNTAX_PROTO2") => Int32(0),
+    Symbol("SYNTAX_PROTO3") => Int32(1),
+]...)
 
 mutable struct Option <: ProtoType
-    name::AbstractString
-    value::_Any
-    Option(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Option
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Option(; kwargs...)
+        obj = new(meta(Option), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Option
+const __meta_Option = Ref{ProtoMeta}()
+function meta(::Type{Option})
+    if !isassigned(__meta_Option)
+        __meta_Option[] = target = ProtoMeta(Option)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :value => _Any]
+        meta(target, Option, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Option[]
+end
+function Base.getproperty(obj::Option, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :value
+        return (obj.__protobuf_jl_internal_values[name])::_Any
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct EnumValue <: ProtoType
-    name::AbstractString
-    number::Int32
-    options::Base.Vector{Option}
-    EnumValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct EnumValue
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
 
-struct __enum_Field_Kind <: ProtoEnum
-    TYPE_UNKNOWN::Int32
-    TYPE_DOUBLE::Int32
-    TYPE_FLOAT::Int32
-    TYPE_INT64::Int32
-    TYPE_UINT64::Int32
-    TYPE_INT32::Int32
-    TYPE_FIXED64::Int32
-    TYPE_FIXED32::Int32
-    TYPE_BOOL::Int32
-    TYPE_STRING::Int32
-    TYPE_GROUP::Int32
-    TYPE_MESSAGE::Int32
-    TYPE_BYTES::Int32
-    TYPE_UINT32::Int32
-    TYPE_ENUM::Int32
-    TYPE_SFIXED32::Int32
-    TYPE_SFIXED64::Int32
-    TYPE_SINT32::Int32
-    TYPE_SINT64::Int32
-    __enum_Field_Kind() = new(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18)
-end #struct __enum_Field_Kind
-const Field_Kind = __enum_Field_Kind()
+    function EnumValue(; kwargs...)
+        obj = new(meta(EnumValue), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct EnumValue
+const __meta_EnumValue = Ref{ProtoMeta}()
+function meta(::Type{EnumValue})
+    if !isassigned(__meta_EnumValue)
+        __meta_EnumValue[] = target = ProtoMeta(EnumValue)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :number => Int32, :options => Base.Vector{Option}]
+        meta(target, EnumValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_EnumValue[]
+end
+function Base.getproperty(obj::EnumValue, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :number
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Option}
+    else
+        getfield(obj, name)
+    end
+end
 
-struct __enum_Field_Cardinality <: ProtoEnum
-    CARDINALITY_UNKNOWN::Int32
-    CARDINALITY_OPTIONAL::Int32
-    CARDINALITY_REQUIRED::Int32
-    CARDINALITY_REPEATED::Int32
-    __enum_Field_Cardinality() = new(0,1,2,3)
-end #struct __enum_Field_Cardinality
-const Field_Cardinality = __enum_Field_Cardinality()
+const Field_Kind = (;[
+    Symbol("TYPE_UNKNOWN") => Int32(0),
+    Symbol("TYPE_DOUBLE") => Int32(1),
+    Symbol("TYPE_FLOAT") => Int32(2),
+    Symbol("TYPE_INT64") => Int32(3),
+    Symbol("TYPE_UINT64") => Int32(4),
+    Symbol("TYPE_INT32") => Int32(5),
+    Symbol("TYPE_FIXED64") => Int32(6),
+    Symbol("TYPE_FIXED32") => Int32(7),
+    Symbol("TYPE_BOOL") => Int32(8),
+    Symbol("TYPE_STRING") => Int32(9),
+    Symbol("TYPE_GROUP") => Int32(10),
+    Symbol("TYPE_MESSAGE") => Int32(11),
+    Symbol("TYPE_BYTES") => Int32(12),
+    Symbol("TYPE_UINT32") => Int32(13),
+    Symbol("TYPE_ENUM") => Int32(14),
+    Symbol("TYPE_SFIXED32") => Int32(15),
+    Symbol("TYPE_SFIXED64") => Int32(16),
+    Symbol("TYPE_SINT32") => Int32(17),
+    Symbol("TYPE_SINT64") => Int32(18),
+]...)
+
+const Field_Cardinality = (;[
+    Symbol("CARDINALITY_UNKNOWN") => Int32(0),
+    Symbol("CARDINALITY_OPTIONAL") => Int32(1),
+    Symbol("CARDINALITY_REQUIRED") => Int32(2),
+    Symbol("CARDINALITY_REPEATED") => Int32(3),
+]...)
 
 mutable struct Field <: ProtoType
-    kind::Int32
-    cardinality::Int32
-    number::Int32
-    name::AbstractString
-    type_url::AbstractString
-    oneof_index::Int32
-    packed::Bool
-    options::Base.Vector{Option}
-    json_name::AbstractString
-    default_value::AbstractString
-    Field(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Field
-const __fnum_Field = Int[1,2,3,4,6,7,8,9,10,11]
-meta(t::Type{Field}) = meta(t, ProtoBuf.DEF_REQ, __fnum_Field, ProtoBuf.DEF_VAL, true, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES, ProtoBuf.DEF_FIELD_TYPES)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Field(; kwargs...)
+        obj = new(meta(Field), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Field
+const __meta_Field = Ref{ProtoMeta}()
+function meta(::Type{Field})
+    if !isassigned(__meta_Field)
+        __meta_Field[] = target = ProtoMeta(Field)
+        fnum = Int[1,2,3,4,6,7,8,9,10,11]
+        allflds = Pair{Symbol,Union{Type,String}}[:kind => Int32, :cardinality => Int32, :number => Int32, :name => AbstractString, :type_url => AbstractString, :oneof_index => Int32, :packed => Bool, :options => Base.Vector{Option}, :json_name => AbstractString, :default_value => AbstractString]
+        meta(target, Field, allflds, ProtoBuf.DEF_REQ, fnum, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Field[]
+end
+function Base.getproperty(obj::Field, name::Symbol)
+    if name === :kind
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :cardinality
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :number
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :type_url
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :oneof_index
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :packed
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Option}
+    elseif name === :json_name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :default_value
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct _Enum <: ProtoType
-    name::AbstractString
-    enumvalue::Base.Vector{EnumValue}
-    options::Base.Vector{Option}
-    source_context::SourceContext
-    syntax::Int32
-    _Enum(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct _Enum
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function _Enum(; kwargs...)
+        obj = new(meta(_Enum), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct _Enum
+const __meta__Enum = Ref{ProtoMeta}()
+function meta(::Type{_Enum})
+    if !isassigned(__meta__Enum)
+        __meta__Enum[] = target = ProtoMeta(_Enum)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :enumvalue => Base.Vector{EnumValue}, :options => Base.Vector{Option}, :source_context => SourceContext, :syntax => Int32]
+        meta(target, _Enum, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta__Enum[]
+end
+function Base.getproperty(obj::_Enum, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :enumvalue
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{EnumValue}
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Option}
+    elseif name === :source_context
+        return (obj.__protobuf_jl_internal_values[name])::SourceContext
+    elseif name === :syntax
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct _Type <: ProtoType
-    name::AbstractString
-    fields::Base.Vector{Field}
-    oneofs::Base.Vector{AbstractString}
-    options::Base.Vector{Option}
-    source_context::SourceContext
-    syntax::Int32
-    _Type(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct _Type
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function _Type(; kwargs...)
+        obj = new(meta(_Type), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct _Type
+const __meta__Type = Ref{ProtoMeta}()
+function meta(::Type{_Type})
+    if !isassigned(__meta__Type)
+        __meta__Type[] = target = ProtoMeta(_Type)
+        allflds = Pair{Symbol,Union{Type,String}}[:name => AbstractString, :fields => Base.Vector{Field}, :oneofs => Base.Vector{AbstractString}, :options => Base.Vector{Option}, :source_context => SourceContext, :syntax => Int32]
+        meta(target, _Type, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta__Type[]
+end
+function Base.getproperty(obj::_Type, name::Symbol)
+    if name === :name
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :fields
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Field}
+    elseif name === :oneofs
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{AbstractString}
+    elseif name === :options
+        return (obj.__protobuf_jl_internal_values[name])::Base.Vector{Option}
+    elseif name === :source_context
+        return (obj.__protobuf_jl_internal_values[name])::SourceContext
+    elseif name === :syntax
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 export Syntax, _Type, Field_Kind, Field_Cardinality, Field, _Enum, EnumValue, Option

--- a/src/google/type_pb.jl
+++ b/src/google/type_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 struct __enum_Syntax <: ProtoEnum
     SYNTAX_PROTO2::Int32
     SYNTAX_PROTO3::Int32

--- a/src/google/wellknown.jl
+++ b/src/google/wellknown.jl
@@ -1,5 +1,10 @@
 module google
+    using ..ProtoBuf
+    import ..ProtoBuf: meta
     module protobuf
+        using ..ProtoBuf
+        import ..ProtoBuf: meta
+
         include("empty_pb.jl")
         include("any_pb.jl")
         include("timestamp_pb.jl")

--- a/src/google/wrappers_pb.jl
+++ b/src/google/wrappers_pb.jl
@@ -18,12 +18,14 @@ mutable struct DoubleValue <: ProtoType
 end # mutable struct DoubleValue
 const __meta_DoubleValue = Ref{ProtoMeta}()
 function meta(::Type{DoubleValue})
-    if !isassigned(__meta_DoubleValue)
-        __meta_DoubleValue[] = target = ProtoMeta(DoubleValue)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => Float64]
-        meta(target, DoubleValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_DoubleValue)
+            __meta_DoubleValue[] = target = ProtoMeta(DoubleValue)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => Float64]
+            meta(target, DoubleValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_DoubleValue[]
     end
-    __meta_DoubleValue[]
 end
 function Base.getproperty(obj::DoubleValue, name::Symbol)
     if name === :value
@@ -52,12 +54,14 @@ mutable struct FloatValue <: ProtoType
 end # mutable struct FloatValue
 const __meta_FloatValue = Ref{ProtoMeta}()
 function meta(::Type{FloatValue})
-    if !isassigned(__meta_FloatValue)
-        __meta_FloatValue[] = target = ProtoMeta(FloatValue)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => Float32]
-        meta(target, FloatValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_FloatValue)
+            __meta_FloatValue[] = target = ProtoMeta(FloatValue)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => Float32]
+            meta(target, FloatValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_FloatValue[]
     end
-    __meta_FloatValue[]
 end
 function Base.getproperty(obj::FloatValue, name::Symbol)
     if name === :value
@@ -86,12 +90,14 @@ mutable struct Int64Value <: ProtoType
 end # mutable struct Int64Value
 const __meta_Int64Value = Ref{ProtoMeta}()
 function meta(::Type{Int64Value})
-    if !isassigned(__meta_Int64Value)
-        __meta_Int64Value[] = target = ProtoMeta(Int64Value)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => Int64]
-        meta(target, Int64Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Int64Value)
+            __meta_Int64Value[] = target = ProtoMeta(Int64Value)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => Int64]
+            meta(target, Int64Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Int64Value[]
     end
-    __meta_Int64Value[]
 end
 function Base.getproperty(obj::Int64Value, name::Symbol)
     if name === :value
@@ -120,12 +126,14 @@ mutable struct UInt64Value <: ProtoType
 end # mutable struct UInt64Value
 const __meta_UInt64Value = Ref{ProtoMeta}()
 function meta(::Type{UInt64Value})
-    if !isassigned(__meta_UInt64Value)
-        __meta_UInt64Value[] = target = ProtoMeta(UInt64Value)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => UInt64]
-        meta(target, UInt64Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_UInt64Value)
+            __meta_UInt64Value[] = target = ProtoMeta(UInt64Value)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => UInt64]
+            meta(target, UInt64Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_UInt64Value[]
     end
-    __meta_UInt64Value[]
 end
 function Base.getproperty(obj::UInt64Value, name::Symbol)
     if name === :value
@@ -154,12 +162,14 @@ mutable struct Int32Value <: ProtoType
 end # mutable struct Int32Value
 const __meta_Int32Value = Ref{ProtoMeta}()
 function meta(::Type{Int32Value})
-    if !isassigned(__meta_Int32Value)
-        __meta_Int32Value[] = target = ProtoMeta(Int32Value)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => Int32]
-        meta(target, Int32Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_Int32Value)
+            __meta_Int32Value[] = target = ProtoMeta(Int32Value)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => Int32]
+            meta(target, Int32Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_Int32Value[]
     end
-    __meta_Int32Value[]
 end
 function Base.getproperty(obj::Int32Value, name::Symbol)
     if name === :value
@@ -188,12 +198,14 @@ mutable struct UInt32Value <: ProtoType
 end # mutable struct UInt32Value
 const __meta_UInt32Value = Ref{ProtoMeta}()
 function meta(::Type{UInt32Value})
-    if !isassigned(__meta_UInt32Value)
-        __meta_UInt32Value[] = target = ProtoMeta(UInt32Value)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => UInt32]
-        meta(target, UInt32Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_UInt32Value)
+            __meta_UInt32Value[] = target = ProtoMeta(UInt32Value)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => UInt32]
+            meta(target, UInt32Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_UInt32Value[]
     end
-    __meta_UInt32Value[]
 end
 function Base.getproperty(obj::UInt32Value, name::Symbol)
     if name === :value
@@ -222,12 +234,14 @@ mutable struct BoolValue <: ProtoType
 end # mutable struct BoolValue
 const __meta_BoolValue = Ref{ProtoMeta}()
 function meta(::Type{BoolValue})
-    if !isassigned(__meta_BoolValue)
-        __meta_BoolValue[] = target = ProtoMeta(BoolValue)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => Bool]
-        meta(target, BoolValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_BoolValue)
+            __meta_BoolValue[] = target = ProtoMeta(BoolValue)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => Bool]
+            meta(target, BoolValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_BoolValue[]
     end
-    __meta_BoolValue[]
 end
 function Base.getproperty(obj::BoolValue, name::Symbol)
     if name === :value
@@ -256,12 +270,14 @@ mutable struct StringValue <: ProtoType
 end # mutable struct StringValue
 const __meta_StringValue = Ref{ProtoMeta}()
 function meta(::Type{StringValue})
-    if !isassigned(__meta_StringValue)
-        __meta_StringValue[] = target = ProtoMeta(StringValue)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => AbstractString]
-        meta(target, StringValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_StringValue)
+            __meta_StringValue[] = target = ProtoMeta(StringValue)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => AbstractString]
+            meta(target, StringValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_StringValue[]
     end
-    __meta_StringValue[]
 end
 function Base.getproperty(obj::StringValue, name::Symbol)
     if name === :value
@@ -290,12 +306,14 @@ mutable struct BytesValue <: ProtoType
 end # mutable struct BytesValue
 const __meta_BytesValue = Ref{ProtoMeta}()
 function meta(::Type{BytesValue})
-    if !isassigned(__meta_BytesValue)
-        __meta_BytesValue[] = target = ProtoMeta(BytesValue)
-        allflds = Pair{Symbol,Union{Type,String}}[:value => Array{UInt8,1}]
-        meta(target, BytesValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    ProtoBuf.metalock() do
+        if !isassigned(__meta_BytesValue)
+            __meta_BytesValue[] = target = ProtoMeta(BytesValue)
+            allflds = Pair{Symbol,Union{Type,String}}[:value => Array{UInt8,1}]
+            meta(target, BytesValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+        end
+        __meta_BytesValue[]
     end
-    __meta_BytesValue[]
 end
 function Base.getproperty(obj::BytesValue, name::Symbol)
     if name === :value

--- a/src/google/wrappers_pb.jl
+++ b/src/google/wrappers_pb.jl
@@ -1,47 +1,308 @@
 # syntax: proto3
 mutable struct DoubleValue <: ProtoType
-    value::Float64
-    DoubleValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct DoubleValue
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function DoubleValue(; kwargs...)
+        obj = new(meta(DoubleValue), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct DoubleValue
+const __meta_DoubleValue = Ref{ProtoMeta}()
+function meta(::Type{DoubleValue})
+    if !isassigned(__meta_DoubleValue)
+        __meta_DoubleValue[] = target = ProtoMeta(DoubleValue)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => Float64]
+        meta(target, DoubleValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_DoubleValue[]
+end
+function Base.getproperty(obj::DoubleValue, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Float64
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct FloatValue <: ProtoType
-    value::Float32
-    FloatValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct FloatValue
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function FloatValue(; kwargs...)
+        obj = new(meta(FloatValue), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct FloatValue
+const __meta_FloatValue = Ref{ProtoMeta}()
+function meta(::Type{FloatValue})
+    if !isassigned(__meta_FloatValue)
+        __meta_FloatValue[] = target = ProtoMeta(FloatValue)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => Float32]
+        meta(target, FloatValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_FloatValue[]
+end
+function Base.getproperty(obj::FloatValue, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Float32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct Int64Value <: ProtoType
-    value::Int64
-    Int64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Int64Value
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Int64Value(; kwargs...)
+        obj = new(meta(Int64Value), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Int64Value
+const __meta_Int64Value = Ref{ProtoMeta}()
+function meta(::Type{Int64Value})
+    if !isassigned(__meta_Int64Value)
+        __meta_Int64Value[] = target = ProtoMeta(Int64Value)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => Int64]
+        meta(target, Int64Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Int64Value[]
+end
+function Base.getproperty(obj::Int64Value, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct UInt64Value <: ProtoType
-    value::UInt64
-    UInt64Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct UInt64Value
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function UInt64Value(; kwargs...)
+        obj = new(meta(UInt64Value), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct UInt64Value
+const __meta_UInt64Value = Ref{ProtoMeta}()
+function meta(::Type{UInt64Value})
+    if !isassigned(__meta_UInt64Value)
+        __meta_UInt64Value[] = target = ProtoMeta(UInt64Value)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => UInt64]
+        meta(target, UInt64Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_UInt64Value[]
+end
+function Base.getproperty(obj::UInt64Value, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::UInt64
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct Int32Value <: ProtoType
-    value::Int32
-    Int32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct Int32Value
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function Int32Value(; kwargs...)
+        obj = new(meta(Int32Value), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct Int32Value
+const __meta_Int32Value = Ref{ProtoMeta}()
+function meta(::Type{Int32Value})
+    if !isassigned(__meta_Int32Value)
+        __meta_Int32Value[] = target = ProtoMeta(Int32Value)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => Int32]
+        meta(target, Int32Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_Int32Value[]
+end
+function Base.getproperty(obj::Int32Value, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct UInt32Value <: ProtoType
-    value::UInt32
-    UInt32Value(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct UInt32Value
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function UInt32Value(; kwargs...)
+        obj = new(meta(UInt32Value), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct UInt32Value
+const __meta_UInt32Value = Ref{ProtoMeta}()
+function meta(::Type{UInt32Value})
+    if !isassigned(__meta_UInt32Value)
+        __meta_UInt32Value[] = target = ProtoMeta(UInt32Value)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => UInt32]
+        meta(target, UInt32Value, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_UInt32Value[]
+end
+function Base.getproperty(obj::UInt32Value, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::UInt32
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct BoolValue <: ProtoType
-    value::Bool
-    BoolValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct BoolValue
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function BoolValue(; kwargs...)
+        obj = new(meta(BoolValue), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct BoolValue
+const __meta_BoolValue = Ref{ProtoMeta}()
+function meta(::Type{BoolValue})
+    if !isassigned(__meta_BoolValue)
+        __meta_BoolValue[] = target = ProtoMeta(BoolValue)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => Bool]
+        meta(target, BoolValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_BoolValue[]
+end
+function Base.getproperty(obj::BoolValue, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct StringValue <: ProtoType
-    value::AbstractString
-    StringValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct StringValue
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function StringValue(; kwargs...)
+        obj = new(meta(StringValue), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct StringValue
+const __meta_StringValue = Ref{ProtoMeta}()
+function meta(::Type{StringValue})
+    if !isassigned(__meta_StringValue)
+        __meta_StringValue[] = target = ProtoMeta(StringValue)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => AbstractString]
+        meta(target, StringValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_StringValue[]
+end
+function Base.getproperty(obj::StringValue, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct BytesValue <: ProtoType
-    value::Array{UInt8,1}
-    BytesValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
-end #mutable struct BytesValue
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function BytesValue(; kwargs...)
+        obj = new(meta(BytesValue), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end # mutable struct BytesValue
+const __meta_BytesValue = Ref{ProtoMeta}()
+function meta(::Type{BytesValue})
+    if !isassigned(__meta_BytesValue)
+        __meta_BytesValue[] = target = ProtoMeta(BytesValue)
+        allflds = Pair{Symbol,Union{Type,String}}[:value => Array{UInt8,1}]
+        meta(target, BytesValue, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_BytesValue[]
+end
+function Base.getproperty(obj::BytesValue, name::Symbol)
+    if name === :value
+        return (obj.__protobuf_jl_internal_values[name])::Array{UInt8,1}
+    else
+        getfield(obj, name)
+    end
+end
 
 export DoubleValue, FloatValue, Int64Value, UInt64Value, Int32Value, UInt32Value, BoolValue, StringValue, BytesValue

--- a/src/google/wrappers_pb.jl
+++ b/src/google/wrappers_pb.jl
@@ -1,7 +1,4 @@
 # syntax: proto3
-using ProtoBuf
-import ProtoBuf.meta
-
 mutable struct DoubleValue <: ProtoType
     value::Float64
     DoubleValue(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)

--- a/src/svc.jl
+++ b/src/svc.jl
@@ -88,8 +88,7 @@ struct GenericProtoServiceStub{B} <: AbstractProtoServiceStub{B}
     blocking::Bool
 
     # This inner constructor syntax works with both Julia .5 and .6
-    function GenericProtoServiceStub{B}(desc::ServiceDescriptor,
-                                        channel::ProtoRpcChannel) where B
+    function GenericProtoServiceStub{B}(desc::ServiceDescriptor, channel::ProtoRpcChannel) where B
         new{B}(desc, channel, B)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,20 +37,6 @@ function deepcopy(from::T) where T <: ProtoType
     to
 end
 
-function add_field!(obj::Any, fld::Symbol, val)
-    typ = typeof(obj)
-    attrib = meta(typ).symdict[fld]
-    (attrib.occurrence != 2) && error("$(typ).$(fld) is not a repeating field")
-
-    ptyp = attrib.ptyp
-    jtyp = WIRETYPES[ptyp][4]
-    (ptyp == :obj) && (jtyp = attrib.meta.jtype)
-
-    !isdefined(obj, fld) && setfield!(obj, fld, jtyp[])
-    push!(getfield(obj, fld), val)
-    nothing
-end
-
 protobuild(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}()) where {T} = _protobuild(T(), collect(nv))
 
 function _protobuild(obj::T, nv) where T

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,100 +2,51 @@
 
 isinitialized(obj::Any) = isfilled(obj)
 
-setproperty!(obj::ProtoType, fld::Symbol, val) = (Core.setfield!(obj, fld, val); fillset(obj, fld); val)
-
-get_field(obj::Any, fld::Symbol) = isfilled(obj, fld) ? getfield(obj, fld) : error("uninitialized field $fld")
-
-clear = fillunset
-
-has_field(obj::Any, fld::Symbol) = isfilled(obj, fld)
-
 function copy!(to::T, from::T) where T <: ProtoType
-    fillunset(to)
-    fill = filled(from)
-    fnames = fld_names(T)
-    for idx in 1:length(fnames)
-        if fill[1, idx]
-            name = fnames[idx]
-            setproperty!(to, name, getfield(from, name))
-        end
+    clear(to)
+    for name in propertynames(from)
+        hasproperty(from, name) && setproperty!(to, name, getproperty(from, name))
     end
     nothing
 end
 
 function deepcopy(from::T) where T <: ProtoType
     to = T()
-    fillunset(to)
-    fill = filled(from)
-    fnames = fld_names(T)
-    for idx in 1:length(fnames)
-        if fill[1, idx]
-            name = fnames[idx]
-            setproperty!(to, name, deepcopy(getfield(from, name)))
-        end
+    for name in propertynames(from)
+        hasproperty(from, name) && setproperty!(to, name, deepcopy(getproperty(from, name)))
     end
     to
 end
 
-protobuild(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}()) where {T} = _protobuild(T(), collect(nv))
-
-function _protobuild(obj::T, nv) where T
-    for (n,v) in nv
-        fldtyp = fld_type(obj, n)
-        setproperty!(obj, n, isa(v, fldtyp) ? v : convert(fldtyp, v))
-    end
-    obj
-end
-
 # hash method that considers fill status of types
-hash(v::T) where {T<:ProtoType} = protohash(v)
-function protohash(v)
+function hash(v::T) where {T<:ProtoType}
     h = 0
-    fill = filled(v)
-    fnames = fld_names(typeof(v))
-    for idx in 1:length(fnames)
-        fill[1, idx] && (h += hash(getfield(v, fnames[idx])))
+    for name in propertynames(v)
+        hasproperty(v, name) && (h += hash(getproperty(v, name)))
     end
     hash(h)
 end
 
 # equality method that considers fill status of types
-==(v1::T, v2::T) where {T<:ProtoType} = protoeq(v1, v2)
-function protoeq(v1::T, v2::T) where T
-    fillv1 = filled(v1)
-    fillv2 = filled(v2)
-    fnames = fld_names(T)
-    for idx in 1:length(fnames)
-        (fillv1[1,idx] == fillv2[1,idx]) || (return false)
-        if fillv1[1,idx]
-            f = fnames[idx]
-            (getfield(v1,f) == getfield(v2,f)) || (return false)
+function ==(v1::T, v2::T) where {T<:ProtoType}
+    for name in propertynames(v1)
+        (hasproperty(v1, name) === hasproperty(v2, name)) || (return false)
+        if hasproperty(v1, name)
+            (getproperty(v1, name) == getproperty(v2, name)) || (return false)
         end
     end
     true
 end
 
 # isequal method that considers fill status of types
-isequal(v1::T, v2::T) where {T<:ProtoType} = protoisequal(v1, v2)
-function protoisequal(v1::T, v2::T) where T
-    fillv1 = filled(v1)
-    fillv2 = filled(v2)
-    fnames = fld_names(T)
-    for idx in 1:length(fnames)
-        (fillv1[1,idx] == fillv2[1,idx]) || (return false)
-        if fillv1[1,idx]
-            f = fnames[idx]
-            isequal(getfield(v1,f), getfield(v2,f)) || (return false)
+function isequal(v1::T, v2::T) where {T<:ProtoType}
+    for name in propertynames(v1)
+        (hasproperty(v1, name) === hasproperty(v2, name)) || (return false)
+        if hasproperty(v1, name)
+            isequal(getproperty(v1, name), getproperty(v2, name)) || (return false)
         end
     end
     true
-end
-
-function enumstr(enumname, t::Int32)
-    for name in fld_names(typeof(enumname))
-        (getfield(enumname, name) == t) && (return string(name))
-    end
-    error(string("Invalid enum value ", t, " for ", typeof(enumname)))
 end
 
 function enumstr(enumname::T, t::Int32) where {T <: NamedTuple}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -112,6 +112,13 @@ function enumstr(enumname, t::Int32)
     error(string("Invalid enum value ", t, " for ", typeof(enumname)))
 end
 
+function enumstr(enumname::T, t::Int32) where {T <: NamedTuple}
+    for name in propertynames(enumname)
+        (getproperty(enumname, name) == t) && (return string(name))
+    end
+    error(string("Invalid enum value ", t))
+end
+
 function protoc(args=``)
     ENV′ = copy(ENV)
     ENV′["PATH"] = string(joinpath(@__DIR__, "..", "plugin"), ":", ENV′["PATH"])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,6 @@
 isinitialized(obj::Any) = isfilled(obj)
 
 setproperty!(obj::ProtoType, fld::Symbol, val) = (Core.setfield!(obj, fld, val); fillset(obj, fld); val)
-@deprecate set_field!(obj::Any, fld::Symbol, val) setproperty!(obj, fld, val)
 
 get_field(obj::Any, fld::Symbol) = isfilled(obj, fld) ? getfield(obj, fld) : error("uninitialized field $fld")
 
@@ -51,7 +50,6 @@ function add_field!(obj::Any, fld::Symbol, val)
     push!(getfield(obj, fld), val)
     nothing
 end
-@deprecate add_field(obj::Any, fld::Symbol, val) add_field!(obj, fld, val)
 
 protobuild(::Type{T}, nv::Dict{Symbol}=Dict{Symbol,Any}()) where {T} = _protobuild(T(), collect(nv))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
 using ProtoBuf, Test
 
-include("testmetalock.jl")
-include("testtypevers.jl")
-include("testutilapi.jl")
-include("testwellknown.jl")
-include("testcodec.jl")
-include("services/testsvc.jl")
-include("testprotoc.jl")
+@testset "ProtoBuf Tests" begin
+    include("testprotoc.jl")
+    include("services/testsvc.jl")
+    include("testmetalock.jl")
+    include("testtypevers.jl")
+    include("testutilapi.jl")
+    include("testwellknown.jl")
+    include("testcodec.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ProtoBuf, Test
 
+include("testmetalock.jl")
 include("testtypevers.jl")
 include("testutilapi.jl")
 include("testwellknown.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test
+using ProtoBuf, Test
 
 include("testtypevers.jl")
 include("testutilapi.jl")

--- a/test/services/testsvc.jl
+++ b/test/services/testsvc.jl
@@ -24,8 +24,32 @@ end
 close(channel::TestRpcChannel) = close(channel.sock)
 
 mutable struct SvcHeader <: ProtoType
-    method::String
-    SvcHeader() = (o=new(); fillunset(o); o)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function SvcHeader(; kwargs...)
+        obj = new(meta(SvcHeader), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+function meta(::Type{SvcHeader})
+    allflds = Pair{Symbol,Union{Type,String}}[:method => AbstractString]
+    meta(ProtoMeta(SvcHeader), SvcHeader, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::SvcHeader, name::Symbol)
+    if name === :method
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
 end
 
 function write_request(channel::TestRpcChannel, controller::TestRpcController, service::ServiceDescriptor, method::MethodDescriptor, request)
@@ -139,7 +163,9 @@ function run_server(srvr::TestServer)
             @async process(srvr, channel)
         end
     catch ex
-        debug_log(controller, "server stopped with exception $ex")
+        if !(isa(ex, Base.IOError) && (ex.code == Base.UV_ECONNABORTED))
+            debug_log(controller, "server stopped with exception $ex")
+        end
     end
     debug_log(controller, "stopped server")
 end

--- a/test/services/testsvc.jl
+++ b/test/services/testsvc.jl
@@ -11,8 +11,8 @@ mutable struct TestRpcController <: ProtoRpcController
     debug::Bool
 end
 
-debug_log(controller::TestRpcController, msg) = controller.debug && println(msg)
-error_log(controller::TestRpcController, msg) = println(stderr, msg)
+debug_log(controller::TestRpcController, msg) = controller.debug && @info(msg)
+error_log(controller::TestRpcController, msg) = @error(msg)
 
 # RpcChannel implementation for our test protocol
 # The protocol is to write and read:

--- a/test/services/testsvc_pb.jl
+++ b/test/services/testsvc_pb.jl
@@ -1,24 +1,66 @@
 # syntax: proto3
 using ProtoBuf
 import ProtoBuf.meta
-import Base: hash, isequal, ==
 
 mutable struct BinaryOpReq <: ProtoType
-    i1::Int64
-    i2::Int64
-    BinaryOpReq(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function BinaryOpReq(; kwargs...)
+        obj = new(meta(BinaryOpReq), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
 end #type BinaryOpReq
-hash(v::BinaryOpReq) = ProtoBuf.protohash(v)
-isequal(v1::BinaryOpReq, v2::BinaryOpReq) = ProtoBuf.protoisequal(v1, v2)
-==(v1::BinaryOpReq, v2::BinaryOpReq) = ProtoBuf.protoeq(v1, v2)
+function meta(::Type{BinaryOpReq})
+    allflds = Pair{Symbol,Union{Type,String}}[:i1 => Int64, :i2 => Int64]
+    meta(ProtoMeta(BinaryOpReq), BinaryOpReq, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::BinaryOpReq, name::Symbol)
+    if name === :i1
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :i2
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct BinaryOpResp <: ProtoType
-    result::Int64
-    BinaryOpResp(; kwargs...) = (o=new(); fillunset(o); isempty(kwargs) || ProtoBuf._protobuild(o, kwargs); o)
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function BinaryOpResp(; kwargs...)
+        obj = new(meta(BinaryOpResp), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
 end #type BinaryOpResp
-hash(v::BinaryOpResp) = ProtoBuf.protohash(v)
-isequal(v1::BinaryOpResp, v2::BinaryOpResp) = ProtoBuf.protoisequal(v1, v2)
-==(v1::BinaryOpResp, v2::BinaryOpResp) = ProtoBuf.protoeq(v1, v2)
+function meta(::Type{BinaryOpResp})
+    allflds = Pair{Symbol,Union{Type,String}}[:result => Int64]
+    meta(ProtoMeta(BinaryOpResp), BinaryOpResp, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::BinaryOpResp, name::Symbol)
+    if name === :result
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    else
+        getfield(obj, name)
+    end
+end
 
 # service methods for TestMath
 const _TestMath_methods = MethodDescriptor[

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -77,6 +77,16 @@ mutable struct __enum_TestEnum <: ProtoEnum
 end
 const TestEnum = __enum_TestEnum()
 
+const TestEnum2 = (;[
+    Symbol("UNIVERSAL") => 0,
+    Symbol("WEB") => 1,
+    Symbol("IMAGES") => 2,
+    Symbol("LOCAL") => 3,
+    Symbol("NEWS") => 4,
+    Symbol("PRODUCTS") => 5,
+    Symbol("VIDEO") => 6,
+]...)
+
 # disable caching of meta since we manually modify them for the tests
 meta(t::Type{TestType})         = meta(t, Symbol[], Int[], Dict{Symbol,Any}(), false)
 meta(t::Type{TestOptional})     = meta(t, Symbol[], Int[], Dict{Symbol,Any}(), false)
@@ -483,6 +493,20 @@ function test_enums()
 
     @test enumstr(TestEnum, TestEnum.LOCAL) == "LOCAL"
     @test_throws ErrorException enumstr(TestEnum, Int32(12))
+end
+
+function test_enums2()
+    print_hdr("enums")
+    @test getfield(TestEnum2, lookup(TestEnum2, 0)) == TestEnum.UNIVERSAL
+    @test getfield(TestEnum2, lookup(TestEnum2, 1)) == TestEnum.WEB
+    @test getfield(TestEnum2, lookup(TestEnum2, 2)) == TestEnum.IMAGES
+    @test getfield(TestEnum2, lookup(TestEnum2, 3)) == TestEnum.LOCAL
+    @test getfield(TestEnum2, lookup(TestEnum2, 4)) == TestEnum.NEWS
+    @test getfield(TestEnum2, lookup(TestEnum2, 5)) == TestEnum.PRODUCTS
+    @test getfield(TestEnum2, lookup(TestEnum2, 6)) == TestEnum.VIDEO
+
+    @test enumstr(TestEnum2, TestEnum2.LOCAL) == "LOCAL"
+    @test_throws ErrorException enumstr(TestEnum2, Int32(12))
 end
 
 end # module ProtoBufTestCodec

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -461,14 +461,6 @@ function test_misc()
     copy!(readfld, testfld)
     assert_equal(readfld, testfld)
 
-    # test add_field!
-    readfld = TestOptional(TestStr("1"), TestStr(""), Int64[])
-    for iVal2 in testfld.iVal2
-        add_field!(readfld, :iVal2, iVal2)
-    end
-    assert_equal(readfld, testfld)
-    @test ProtoBuf.protoisequal(readfld, testfld)
-
     tf = TestFilled()
     @test !isfilled(tf)
     tf.fld1 = TestType("")

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -2,8 +2,6 @@ module ProtoBufTestCodec
 using ProtoBuf
 using Test
 using Random
-import Base: ==
-
 import ProtoBuf.meta
 
 macro _rand_int(T,mx,a)
@@ -14,118 +12,280 @@ end
 
 print_hdr(tname) = println("testing $tname...")
 
+const TestTypeJType = Ref{Type}(Int64)
+const TestTypeWType = Ref{Symbol}(:int64)
+const TestTypeFldNum = Ref{Int}(1)
+const TestTypePack = Ref{Vector{Symbol}}(ProtoBuf.DEF_PACK)
 mutable struct TestType <: ProtoType
-    val::Any
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function TestType(; kwargs...)
+        obj = new(meta(TestType), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+function meta(::Type{TestType})
+    allflds = Pair{Symbol,Union{Type,String}}[:val => TestTypeJType[]]
+    wtypes = Dict{Symbol,Symbol}(:val => TestTypeWType[])
+    meta(ProtoMeta(TestType), TestType, allflds, ProtoBuf.DEF_REQ, [TestTypeFldNum[]], ProtoBuf.DEF_VAL, TestTypePack[], wtypes, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::TestType, name::Symbol)
+    if name === :val
+        return (obj.__protobuf_jl_internal_values[name])::Any
+    else
+        getfield(obj, name)
+    end
 end
 
 mutable struct TestStr <: ProtoType
-    val::AbstractString
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function TestStr(; kwargs...)
+        obj = new(meta(TestStr), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
 end
-==(t1::TestStr, t2::TestStr) = (t1.val == t2.val)
+function meta(::Type{TestStr})
+    allflds = Pair{Symbol,Union{Type,String}}[:val => AbstractString]
+    meta(ProtoMeta(TestStr), TestStr, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::TestStr, name::Symbol)
+    if name === :val
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    else
+        getfield(obj, name)
+    end
+end
 
 mutable struct TestOptional <: ProtoType
-    sVal1::TestStr
-    sVal2::TestStr
-    iVal2::Array{Int64,1}
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function TestOptional(; kwargs...)
+        obj = new(meta(TestOptional), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+const TestOptionalReq = Symbol[]
+function meta(::Type{TestOptional})
+    allflds = Pair{Symbol,Union{Type,String}}[:sVal1 => TestStr, :sVal2 => TestStr, :iVal2 => Array{Int64,1}]
+    meta(ProtoMeta(TestOptional), TestOptional, allflds, TestOptionalReq, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::TestOptional, name::Symbol)
+    if name === :sVal1
+        return (obj.__protobuf_jl_internal_values[name])::TestStr
+    elseif name === :sVal2
+        return (obj.__protobuf_jl_internal_values[name])::TestStr
+    elseif name === :iVal2
+        return (obj.__protobuf_jl_internal_values[name])::Array{Int64,1}
+    else
+        getfield(obj, name)
+    end
 end
 
 mutable struct TestNested <: ProtoType
-    fld1::TestType
-    fld2::TestOptional
-    fld3::Array{TestStr}
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function TestNested(; kwargs...)
+        obj = new(meta(TestNested), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+
+end
+const TestNestedReq = Symbol[]
+function meta(::Type{TestNested})
+    allflds = Pair{Symbol,Union{Type,String}}[:fld1 => TestType, :fld2 => TestOptional, :fld3 => Array{TestStr,1}]
+    meta(ProtoMeta(TestNested), TestNested, allflds, TestNestedReq, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::TestNested, name::Symbol)
+    if name === :fld1
+        return (obj.__protobuf_jl_internal_values[name])::TestType
+    elseif name === :fld2
+        return (obj.__protobuf_jl_internal_values[name])::TestOptional
+    elseif name === :fld3
+        return (obj.__protobuf_jl_internal_values[name])::Array{TestStr,1}
+    else
+        getfield(obj, name)
+    end
 end
 
 mutable struct TestDefaults <: ProtoType
-    iVal1::Int64
-    sVal2::AbstractString
-    iVal2::Array{Int64,1}
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
 
-    TestDefaults(f1,f2,f3) = new(f1,f2,f3)
-    TestDefaults() = new()
+    function TestDefaults(; kwargs...)
+        obj = new(meta(TestDefaults), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+function meta(::Type{TestDefaults})
+    allflds = Pair{Symbol,Union{Type,String}}[:iVal1 => Int64, :sVal2 => AbstractString, :iVal2 => Array{Int64,1}]
+    defaults = Dict{Symbol,Any}(:iVal1 => 10, :iVal2 => [1,2,3])
+    meta(ProtoMeta(TestDefaults), TestDefaults, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, defaults, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::TestDefaults, name::Symbol)
+    if name === :iVal1
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :sVal2
+        return (obj.__protobuf_jl_internal_values[name])::AbstractString
+    elseif name === :iVal2
+        return (obj.__protobuf_jl_internal_values[name])::Array{Int64,1}
+    else
+        getfield(obj, name)
+    end
 end
 
 mutable struct TestOneofs <: ProtoType
-    iVal1::Int64
-    iVal2::Int64
-    iVal3::Int64
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
 
-    TestOneofs() = new()
+    function TestOneofs(; kwargs...)
+        obj = new(meta(TestOneofs), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+function meta(::Type{TestOneofs})
+    allflds = Pair{Symbol,Union{Type,String}}[:iVal1 => Int64, :iVal2 => Int64, :iVal3 => Int64]
+    oneofs = Int[0,1,1]
+    oneof_names = [:optval]
+    meta(ProtoMeta(TestOneofs), TestOneofs, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, oneofs, oneof_names)
+end
+function Base.getproperty(obj::TestOneofs, name::Symbol)
+    if name === :iVal1
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :iVal2
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :iVal3
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    else
+        getfield(obj, name)
+    end
 end
 
 mutable struct TestMaps <: ProtoType
-    d1::Dict{Int,Int}
-    d2::Dict{Int32,String}
-    d3::Dict{String,String}
-    TestMaps() = new()
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function TestMaps(; kwargs...)
+        obj = new(meta(TestMaps), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+function meta(::Type{TestMaps})
+    allflds = Pair{Symbol,Union{Type,String}}[:d1 => Dict{Int,Int}, :d2 => Dict{Int32,String}, :d3 => Dict{String,String}]
+    meta(ProtoMeta(TestMaps), TestMaps, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::TestMaps, name::Symbol)
+    if name === :d1
+        return (obj.__protobuf_jl_internal_values[name])::Dict{Int,Int}
+    elseif name === :d2
+        return (obj.__protobuf_jl_internal_values[name])::Dict{Int32,String}
+    elseif name === :d3
+        return (obj.__protobuf_jl_internal_values[name])::Dict{String,String}
+    else
+        getfield(obj, name)
+    end
 end
 
 mutable struct TestFilled <: ProtoType
-    fld1::TestType
-    fld2::TestType
-    TestFilled() = new()
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function TestFilled(; kwargs...)
+        obj = new(meta(TestFilled), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+function meta(::Type{TestFilled})
+    allflds = Pair{Symbol,Union{Type,String}}[:fld1 => TestType, :fld2 => TestType]
+    meta(ProtoMeta(TestFilled), TestFilled, allflds, [:fld1], ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+end
+function Base.getproperty(obj::TestFilled, name::Symbol)
+    if name === :fld1
+        return (obj.__protobuf_jl_internal_values[name])::TestType
+    elseif name === :fld2
+        return (obj.__protobuf_jl_internal_values[name])::TestType
+    else
+        getfield(obj, name)
+    end
 end
 
-mutable struct __enum_TestEnum <: ProtoEnum
-    UNIVERSAL::Int32
-    WEB::Int32
-    IMAGES::Int32
-    LOCAL::Int32
-    NEWS::Int32
-    PRODUCTS::Int32
-    VIDEO::Int32
-    __enum_TestEnum() = new(0,1,2,3,4,5,6)
-end
-const TestEnum = __enum_TestEnum()
-
-const TestEnum2 = (;[
-    Symbol("UNIVERSAL") => 0,
-    Symbol("WEB") => 1,
-    Symbol("IMAGES") => 2,
-    Symbol("LOCAL") => 3,
-    Symbol("NEWS") => 4,
-    Symbol("PRODUCTS") => 5,
-    Symbol("VIDEO") => 6,
+const TestEnum = (;[
+    Symbol("UNIVERSAL") => Int32(0),
+    Symbol("WEB") => Int32(1),
+    Symbol("IMAGES") => Int32(2),
+    Symbol("LOCAL") => Int32(3),
+    Symbol("NEWS") => Int32(4),
+    Symbol("PRODUCTS") => Int32(5),
+    Symbol("VIDEO") => Int32(6),
 ]...)
-
-# disable caching of meta since we manually modify them for the tests
-meta(t::Type{TestType})         = meta(t, Symbol[], Int[], Dict{Symbol,Any}(), false)
-meta(t::Type{TestOptional})     = meta(t, Symbol[], Int[], Dict{Symbol,Any}(), false)
-meta(t::Type{TestNested})       = meta(t, Symbol[], Int[], Dict{Symbol,Any}(), false)
-const _t_defaults = Dict{Symbol,Any}(:iVal1 => 10, :iVal2 => [1,2,3])
-meta(t::Type{TestDefaults})     = meta(t, Symbol[], Int[], _t_defaults, false)
-const _t_oneofs = Int[0,1,1]
-const _t_oneof_names = [:optval]
-meta(t::Type{TestOneofs})       = meta(t,  Symbol[], Int[], Dict{Symbol,Any}(), false, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, _t_oneofs, _t_oneof_names)
-meta(t::Type{TestFilled})       = meta(t, Symbol[:fld1], Int[], Dict{Symbol,Any}())
-
-function mk_test_nested_meta(o1::Bool, o2::Bool, o21::Bool, o22::Bool)
-    meta1 = mk_test_meta(1, :int64)
-    meta2 = mk_test_optional_meta(o21, o22)
-
-    m = meta(TestNested)
-    m.symdict[:fld1].occurrence = o1 ? 0 : 1
-    m.symdict[:fld2].occurrence = o2 ? 0 : 1
-    m.symdict[:fld1].meta = meta1
-    m.symdict[:fld2].meta = meta2
-    m
-end
-
-function mk_test_optional_meta(opt1::Bool, opt2::Bool)
-    m = meta(TestOptional)
-    m.symdict[:sVal1].occurrence = opt1 ? 0 : 1
-    m.symdict[:sVal2].occurrence = opt2 ? 0 : 1
-    m
-end
-
-function mk_test_meta(fldnum::Int, ptyp::Symbol)
-    m = meta(TestType)
-    attrib = m.symdict[:val]
-    attrib.fldnum = fldnum
-    attrib.ptyp = ptyp
-    m.numdict = Dict{Int,ProtoMetaAttribs}()
-    m.numdict[fldnum] = attrib
-    m
-end
 
 assert_equal(::Type{Array{T,1}}, ::Type{Array{U,1}}) where {T,U} = @test (T <: U) || (U <: T)
 assert_equal(T::Type, U::Type) = @test (T <: U) || (U <: T)
@@ -139,40 +299,43 @@ function assert_equal(val1, val2)
     typ1 = typeof(val1)
     typ2 = typeof(val2)
     assert_equal(typ1, typ2)
-   
-    n = fieldnames(typ1)
-    t = typ1.types 
-    for fld in n
-        fldfill1 = isfilled(val1, fld)
-        fldfill2 = isfilled(val2, fld)
+
+    for fld in propertynames(typ1)
+        fldfill1 = hasproperty(val1, fld)
+        fldfill2 = hasproperty(val2, fld)
         @test fldfill1 == fldfill2
-        fldfill1 && assert_equal(getfield(val1, fld), getfield(val2, fld))
+        fldfill1 && assert_equal(getproperty(val1, fld), getproperty(val2, fld))
     end
 end
 
 function test_types()
     pb = PipeBuffer()
-    testval = TestType(0)
-    readval = TestType(0)
 
     # test enum
     print_hdr("enum")
-    testval.val = @_rand_int(Int32, 10^9, 0)
-    fldnum = @_rand_int(Int, 100, 1)
-    meta = mk_test_meta(fldnum, :enum)
-    writeproto(pb, testval, meta)
-    readproto(pb, readval, meta)
+    TestTypeJType[] = Int32
+    TestTypeWType[] = :int32
+    TestTypePack[] = ProtoBuf.DEF_PACK
+    TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+    testmeta = meta(TestType)
+    testval = TestType(; val=@_rand_int(Int32, 10^9, 0))
+    readval = TestType()
+    writeproto(pb, testval, testmeta)
+    readproto(pb, readval, testmeta)
     assert_equal(testval, readval)
 
     let typs = [Int32,Int64,UInt32,UInt64,Int32,Int64,UInt64,Int64,UInt32,Int32], ptyps=[:int32,:int64,:uint32,:uint64,:sint32,:sint64,:fixed64,:sfixed64,:fixed32,:sfixed32]
         for (typ,ptyp) in zip(typs,ptyps)
             print_hdr(ptyp)
+            TestTypeJType[] = typ
+            TestTypeWType[] = ptyp
             for idx in 1:100
-                testval.val = convert(typ, @_rand_int(UInt32, 10^9, 0))
-                fldnum = @_rand_int(Int, 100, 1)
-                meta = mk_test_meta(fldnum, ptyp)
-                writeproto(pb, testval, meta)
-                readproto(pb, readval, meta)
+                TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+                testmeta = meta(TestType)
+                testval = TestType(; val=convert(typ, @_rand_int(UInt32, 10^9, 0)))
+                readval = TestType()
+                writeproto(pb, testval, testmeta)
+                readproto(pb, readval, testmeta)
                 assert_equal(testval, readval)
             end
         end
@@ -181,12 +344,15 @@ function test_types()
     let typs = [Int32,Int64,Int32,Int64], ptyps=[:int32,:int64,:sint32,:sint64]
         for (typ,ptyp) in zip(typs,ptyps)
             print_hdr(ptyp)
+            TestTypeJType[] = typ
+            TestTypeWType[] = ptyp
             for idx in 1:100
-                testval.val = convert(typ, -1 * @_rand_int(Int32, 10^9, 0))
-                fldnum = @_rand_int(Int, 100, 1)
-                meta = mk_test_meta(fldnum, ptyp)
-                writeproto(pb, testval, meta)
-                readproto(pb, readval, meta)
+                TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+                testmeta = meta(TestType)
+                testval = TestType(; val=convert(typ, @_rand_int(UInt32, 10^9, 0)))
+                readval = TestType()
+                writeproto(pb, testval, testmeta)
+                readproto(pb, readval, testmeta)
                 assert_equal(testval, readval)
             end
         end
@@ -204,12 +370,15 @@ function test_types()
     let typs = [Bool], ptyps=[:bool]
         for (typ,ptyp) in zip(typs,ptyps)
             print_hdr(ptyp)
+            TestTypeJType[] = typ
+            TestTypeWType[] = ptyp
             for idx in 1:100
-                testval.val = convert(typ, @_rand_int(UInt32, 1, 0))
-                fldnum = @_rand_int(Int, 100, 1)
-                meta = mk_test_meta(fldnum, ptyp)
-                writeproto(pb, testval, meta)
-                readproto(pb, readval, meta)
+                TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+                testmeta = meta(TestType)
+                testval = TestType(; val=convert(typ, @_rand_int(UInt32, 1, 0)))
+                readval = TestType()
+                writeproto(pb, testval, testmeta)
+                readproto(pb, readval, testmeta)
                 assert_equal(testval, readval)
             end
         end
@@ -218,67 +387,77 @@ function test_types()
     let typs = [Float64,Float32], ptyps=[:double,:float]
         for (typ,ptyp) in zip(typs,ptyps)
             print_hdr(ptyp)
+            TestTypeJType[] = typ
+            TestTypeWType[] = ptyp
             for idx in 1:100
-                testval.val = convert(typ, @_rand_int(UInt32, 10^9, 0))
-                fldnum = @_rand_int(Int, 100, 1)
-                meta = mk_test_meta(fldnum, ptyp)
-                writeproto(pb, testval, meta) 
-                readproto(pb, readval, meta)
+                TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+                testmeta = meta(TestType)
+                testval = TestType(; val=convert(typ, @_rand_int(UInt32, 10^9, 0)))
+                readval = TestType()
+                writeproto(pb, testval, testmeta)
+                readproto(pb, readval, testmeta)
                 assert_equal(testval, readval)
             end
         end
     end
 
-    print_hdr("string")
-    for idx in 1:100
-        testval.val = randstring(50)
-        fldnum = @_rand_int(Int, 100, 1)
-        meta = mk_test_meta(fldnum, :string)
-        writeproto(pb, testval, meta) 
-        readproto(pb, readval, meta)
-        assert_equal(testval, readval)
+    let typs = [AbstractString], ptyps=[:string]
+        for (typ,ptyp) in zip(typs,ptyps)
+            print_hdr("string")
+            TestTypeJType[] = typ
+            TestTypeWType[] = ptyp
+            for idx in 1:100
+                TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+                testmeta = meta(TestType)
+                testval = TestType(; val=randstring(50))
+                readval = TestType()
+                writeproto(pb, testval, testmeta)
+                readproto(pb, readval, testmeta)
+                assert_equal(testval, readval)
+            end
+        end
     end
 end
 
 function test_repeats()
     pb = PipeBuffer()
-    testval = TestType(0)
-    readval = TestType(0)
 
     print_hdr("repeated int64")
+    TestTypeJType[] = Vector{Int64}
+    TestTypeWType[] = :int64
+    TestTypePack[] = ProtoBuf.DEF_PACK
     for idx in 1:100
-        testval.val = collect(Int64, randstring(50))
-        readval.val = Int64[]
-        fldnum = @_rand_int(Int, 100, 1)
-        meta = mk_test_meta(fldnum, :int64)
-        meta.ordered[1].occurrence = 2
-        writeproto(pb, testval, meta) 
-        readproto(pb, readval, meta)
+        TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+        testval = TestType(; val=collect(Int64, randstring(50)))
+        readval = TestType()
+        testmeta = meta(TestType)
+        writeproto(pb, testval, testmeta)
+        readproto(pb, readval, testmeta)
         assert_equal(testval, readval)
     end
 
     print_hdr("repeated and packed int64")
+    TestTypePack[] = Symbol[:val]
     for idx in 1:100
-        testval.val = collect(Int64, randstring(50))
-        readval.val = Int64[]
-        fldnum = @_rand_int(Int, 100, 1)
-        meta = mk_test_meta(fldnum, :int64)
-        meta.ordered[1].occurrence = 2
-        meta.ordered[1].packed = true
-        writeproto(pb, testval, meta) 
-        readproto(pb, readval, meta)
+        TestTypeFldNum[] = @_rand_int(Int, 100, 1)
+        testval = TestType(; val=collect(Int64, randstring(50)))
+        readval = TestType()
+        testmeta = meta(TestType)
+        writeproto(pb, testval, testmeta)
+        readproto(pb, readval, testmeta)
         assert_equal(testval, readval)
     end
 
     print_hdr("repeated string")
+    TestTypeJType[] = Vector{AbstractString}
+    TestTypeWType[] = :string
+    TestTypePack[] = ProtoBuf.DEF_PACK
     for idx in 1:100
-        testval.val = [randstring(5) for i in 1:10] 
-        readval.val = AbstractString[]
-        fldnum = @_rand_int(Int, 100, 1)
-        meta = mk_test_meta(fldnum, :string)
-        meta.ordered[1].occurrence = 2
-        writeproto(pb, testval, meta) 
-        readproto(pb, readval, meta)
+        testval = TestType(; val=AbstractString[randstring(5) for i in 1:10])
+        readval = TestType()
+        testmeta = meta(TestType)
+        writeproto(pb, testval, testmeta)
+        readproto(pb, readval, testmeta)
         assert_equal(testval, readval)
     end
 end
@@ -286,25 +465,29 @@ end
 function test_optional()
     print_hdr("optional fields")
     pb = PipeBuffer()
-    testval = TestOptional(TestStr(""), TestStr(""), Int64[1,2,3])
-    readval = TestOptional(TestStr(""), TestStr(""), Int64[])
+    testval = TestOptional(; sVal1=TestStr(; val=""), sVal2=TestStr(; val=""), iVal2=Int64[1,2,3])
+    readval = TestOptional(; sVal1=TestStr(; val=""), sVal2=TestStr(; val=""), iVal2=Int64[])
 
     for idx in 1:100
-        testval.sVal1 = TestStr(string(@_rand_int(Int, 100, 0)))
-        testval.sVal2 = TestStr(randstring(5))
+        testval.sVal1 = TestStr(; val=string(@_rand_int(Int, 100, 0)))
+        testval.sVal2 = TestStr(; val=randstring(5))
         testval.iVal2 = Int64[@_rand_int(Int,100,0) for i in 1:10]
-        sVal1Opt = rand(Bool)
-        sVal2Opt = rand(Bool)
-        meta = mk_test_optional_meta(sVal1Opt, sVal2Opt)
-        fillunset(testval)
-        fillset(testval, :iVal2)
-        !sVal1Opt && fillset(testval, :sVal1)
-        !sVal2Opt && fillset(testval, :sVal2)
 
-        writeproto(pb, testval, meta)
-        readval.iVal2 = Int64[]
-        readproto(pb, readval, meta)
-
+        empty!(TestOptionalReq)
+        kwargs = Dict{Symbol,Any}(:iVal2 => Int64[@_rand_int(Int,100,0) for i in 1:10])
+        if rand(Bool)
+            push!(TestOptionalReq, :sVal1)
+            kwargs[:sVal1] = TestStr(; val=string(@_rand_int(Int, 100, 0)))
+        end
+        if rand(Bool)
+            push!(TestOptionalReq, :sVal2)
+            kwargs[:sVal2] = TestStr(; val=randstring(5))
+        end
+        testval = TestOptional(; kwargs...)
+        readval = TestOptional()
+        testmeta = meta(TestOptional)
+        writeproto(pb, testval, testmeta)
+        readproto(pb, readval, testmeta)
         assert_equal(testval, readval)
     end
 end
@@ -313,39 +496,44 @@ function test_nested()
     print_hdr("nested types")
     pb = PipeBuffer()
 
-    testfld1 = TestType(0)
-    readfld1 = TestType(0)
-    testfld2 = TestOptional(TestStr("1"), TestStr(""), Int64[1,2,3])
-    readfld2 = TestOptional(TestStr("1"), TestStr(""), Int64[])
-    testval = TestNested(testfld1, testfld2, [TestStr("hello"), TestStr("world")])
-    readval = TestNested(readfld1, readfld2, TestStr[])
+    TestTypeJType[] = Int64
+    TestTypeWType[] = :int64
+    TestTypePack[] = ProtoBuf.DEF_PACK
+    TestTypeFldNum[] = 1
 
     for idx in 1:100
-        testfld1.val = @_rand_int(Int64, 10^9, 0)
-        testfld2.sVal1 = TestStr(string(@_rand_int(Int, 100, 0)))
-        testfld2.sVal2 = TestStr(randstring(5))
-        testfld2.iVal2 = Int64[@_rand_int(Int, 100, 0) for i in 1:10]
-
         o1 = rand(Bool)
         o2 = rand(Bool)
         o21 = rand(Bool)
         o22 = rand(Bool)
-        meta = mk_test_nested_meta(o1, o2, o21, o22)
 
-        fillunset(testval)
-        fillset(testval, :fld3)
-        !o1 && fillset(testval, :fld1)
-        !o2 && fillset(testval, :fld2)
+        empty!(TestNestedReq)
+        testnestedkwargs = Dict{Symbol,Any}()
+        if o1
+            push!(TestNestedReq, :fld1)
+            testnestedkwargs[:fld1] = TestType(; val=@_rand_int(Int64, 10^9, 0))
+        end
+        if o2
+            push!(TestNestedReq, :fld2)
+            empty!(TestOptionalReq)
+            testfld2kwargs = Dict{Symbol,Any}(:iVal2=>Int64[@_rand_int(Int, 100, 0) for i in 1:10])
+            if o21
+                push!(TestOptionalReq, :sVal1)
+                testfld2kwargs[:sVal1] = TestStr(; val=string(@_rand_int(Int, 100, 0)))
+            end
+            if o22
+                push!(TestOptionalReq, :sVal2)
+                testfld2kwargs[:sVal2] = TestStr(; val=randstring(5))
+            end
+            testnestedkwargs[:fld2] = TestOptional(; testfld2kwargs...)
+        end
 
-        fillunset(testfld2)
-        fillset(testfld2, :iVal2)
-        !o21 && fillset(testfld2, :sVal1)
-        !o22 && fillset(testfld2, :sVal2)
+        testval = TestNested(; testnestedkwargs...)
+        readval = TestNested()
+        testmeta = meta(TestNested)
 
-        writeproto(pb, testval, meta)
-        readfld2.iVal2 = Int64[]
-        readval.fld3 = TestStr[]
-        readproto(pb, readval, meta)
+        writeproto(pb, testval, testmeta)
+        readproto(pb, readval, testmeta)
 
         assert_equal(testval, readval)
     end
@@ -361,34 +549,34 @@ function test_defaults()
     writeproto(pb, testval)
     readproto(pb, readval)
 
-    assert_equal(TestDefaults(testval.iVal1, "", [1,2,3]), readval)
+    assert_equal(TestDefaults(; iVal1=testval.iVal1, sVal2="", iVal2=[1,2,3]), readval)
 end
 
 function test_oneofs()
     print_hdr("oneofs")
-    testval = TestOneofs()
+    testval = TestOneofs(; iVal1=1, iVal3=3)
     @test isfilled(testval)
-    @test isfilled(testval, :iVal1)
-    @test !isfilled(testval, :iVal2)
-    @test isfilled(testval, :iVal3)
+    @test hasproperty(testval, :iVal1)
+    @test !hasproperty(testval, :iVal2)
+    @test hasproperty(testval, :iVal3)
     @test which_oneof(testval, :optval) === :iVal3
 
     testval.iVal2 = 10
-    @test isfilled(testval, :iVal1)
-    @test isfilled(testval, :iVal2)
-    @test !isfilled(testval, :iVal3)
+    @test hasproperty(testval, :iVal1)
+    @test hasproperty(testval, :iVal2)
+    @test !hasproperty(testval, :iVal3)
     @test which_oneof(testval, :optval) === :iVal2
 
     testval.iVal1 = 10
-    @test isfilled(testval, :iVal1)
-    @test isfilled(testval, :iVal2)
-    @test !isfilled(testval, :iVal3)
+    @test hasproperty(testval, :iVal1)
+    @test hasproperty(testval, :iVal2)
+    @test !hasproperty(testval, :iVal3)
     @test which_oneof(testval, :optval) === :iVal2
 
     testval.iVal3 = 10
-    @test isfilled(testval, :iVal1)
-    @test !isfilled(testval, :iVal2)
-    @test isfilled(testval, :iVal3)
+    @test hasproperty(testval, :iVal1)
+    @test !hasproperty(testval, :iVal2)
+    @test hasproperty(testval, :iVal3)
     @test which_oneof(testval, :optval) === :iVal3
 end
 
@@ -407,21 +595,21 @@ function test_maps()
     testval.d1 = Dict{Int,Int}()
     writeproto(pb, testval)
     readproto(pb, readval)
-    @test !isfilled(readval, :d1)
+    @test !hasproperty(readval, :d1)
 
     testval = TestMaps()
     readval = TestMaps()
     testval.d2 = Dict{Int32,String}()
     writeproto(pb, testval)
     readproto(pb, readval)
-    @test !isfilled(readval, :d2)
+    @test !hasproperty(readval, :d2)
 
     testval = TestMaps()
     readval = TestMaps()
     testval.d3 = Dict{String,String}()
     writeproto(pb, testval)
     readproto(pb, readval)
-    @test !isfilled(readval, :d3)
+    @test !hasproperty(readval, :d3)
 
     testval = TestMaps()
     readval = TestMaps()
@@ -430,7 +618,7 @@ function test_maps()
     testval.d1[2] = 2
     writeproto(pb, testval)
     readproto(pb, readval)
-    @test isfilled(readval, :d1)
+    @test hasproperty(readval, :d1)
     assert_equal(testval, readval)
 
     testval = TestMaps()
@@ -440,7 +628,7 @@ function test_maps()
     testval.d2[Int32(2)] = convert(String, "Two")
     writeproto(pb, testval)
     readproto(pb, readval)
-    @test isfilled(readval, :d2)
+    @test hasproperty(readval, :d2)
     assert_equal(testval, readval)
 
     testval = TestMaps()
@@ -450,21 +638,24 @@ function test_maps()
     testval.d3["2"] = "Two"
     writeproto(pb, testval)
     readproto(pb, readval)
-    @test isfilled(readval, :d3)
+    @test hasproperty(readval, :d3)
     assert_equal(testval, readval)
 end
 
 function test_misc()
     print_hdr("misc functionality")
-    testfld = TestOptional(TestStr("1"), TestStr(""), Int64[1,2,3])
-    readfld = TestOptional(TestStr(""), TestStr("1"), Int64[])
+    testfld = TestOptional(; sVal1=TestStr(; val="1"), sVal2=TestStr(; val=""), iVal2=Int64[1,2,3])
+    readfld = TestOptional(; sVal1=TestStr(; val=""), sVal2=TestStr(; val="1"), iVal2=Int64[])
     copy!(readfld, testfld)
     assert_equal(readfld, testfld)
 
     tf = TestFilled()
     @test !isfilled(tf)
-    tf.fld1 = TestType("")
-    fillset(tf, :fld1)
+    TestTypeJType[] = AbstractString
+    TestTypeWType[] = :string
+    TestTypeFldNum[] = 1
+    TestTypePack[] = ProtoBuf.DEF_PACK
+    tf.fld1 = TestType(; val="")
     @test isfilled(tf)
 
     iob = IOBuffer()
@@ -487,20 +678,6 @@ function test_enums()
     @test_throws ErrorException enumstr(TestEnum, Int32(12))
 end
 
-function test_enums2()
-    print_hdr("enums")
-    @test getproperty(TestEnum2, lookup(TestEnum2, 0)) == TestEnum.UNIVERSAL
-    @test getproperty(TestEnum2, lookup(TestEnum2, 1)) == TestEnum.WEB
-    @test getproperty(TestEnum2, lookup(TestEnum2, 2)) == TestEnum.IMAGES
-    @test getproperty(TestEnum2, lookup(TestEnum2, 3)) == TestEnum.LOCAL
-    @test getproperty(TestEnum2, lookup(TestEnum2, 4)) == TestEnum.NEWS
-    @test getproperty(TestEnum2, lookup(TestEnum2, 5)) == TestEnum.PRODUCTS
-    @test getproperty(TestEnum2, lookup(TestEnum2, 6)) == TestEnum.VIDEO
-
-    @test enumstr(TestEnum2, TestEnum2.LOCAL) == "LOCAL"
-    @test_throws ErrorException enumstr(TestEnum2, Int32(12))
-end
-
 end # module ProtoBufTestCodec
 
 ProtoBufTestCodec.test_types()
@@ -512,8 +689,3 @@ ProtoBufTestCodec.test_optional()
 ProtoBufTestCodec.test_nested()
 ProtoBufTestCodec.test_defaults()
 ProtoBufTestCodec.test_misc()
-GC.gc()
-println("_metacache has $(length(ProtoBuf._metacache)) entries")
-#println(ProtoBuf._metacache)
-println("_fillcache has $(length(ProtoBuf._fillcache)) entries")
-#println(ProtoBuf._fillcache)

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -483,13 +483,13 @@ end
 
 function test_enums()
     print_hdr("enums")
-    @test getfield(TestEnum, lookup(TestEnum, 0)) == TestEnum.UNIVERSAL
-    @test getfield(TestEnum, lookup(TestEnum, 1)) == TestEnum.WEB
-    @test getfield(TestEnum, lookup(TestEnum, 2)) == TestEnum.IMAGES
-    @test getfield(TestEnum, lookup(TestEnum, 3)) == TestEnum.LOCAL
-    @test getfield(TestEnum, lookup(TestEnum, 4)) == TestEnum.NEWS
-    @test getfield(TestEnum, lookup(TestEnum, 5)) == TestEnum.PRODUCTS
-    @test getfield(TestEnum, lookup(TestEnum, 6)) == TestEnum.VIDEO
+    @test getproperty(TestEnum, lookup(TestEnum, 0)) == TestEnum.UNIVERSAL
+    @test getproperty(TestEnum, lookup(TestEnum, 1)) == TestEnum.WEB
+    @test getproperty(TestEnum, lookup(TestEnum, 2)) == TestEnum.IMAGES
+    @test getproperty(TestEnum, lookup(TestEnum, 3)) == TestEnum.LOCAL
+    @test getproperty(TestEnum, lookup(TestEnum, 4)) == TestEnum.NEWS
+    @test getproperty(TestEnum, lookup(TestEnum, 5)) == TestEnum.PRODUCTS
+    @test getproperty(TestEnum, lookup(TestEnum, 6)) == TestEnum.VIDEO
 
     @test enumstr(TestEnum, TestEnum.LOCAL) == "LOCAL"
     @test_throws ErrorException enumstr(TestEnum, Int32(12))
@@ -497,13 +497,13 @@ end
 
 function test_enums2()
     print_hdr("enums")
-    @test getfield(TestEnum2, lookup(TestEnum2, 0)) == TestEnum.UNIVERSAL
-    @test getfield(TestEnum2, lookup(TestEnum2, 1)) == TestEnum.WEB
-    @test getfield(TestEnum2, lookup(TestEnum2, 2)) == TestEnum.IMAGES
-    @test getfield(TestEnum2, lookup(TestEnum2, 3)) == TestEnum.LOCAL
-    @test getfield(TestEnum2, lookup(TestEnum2, 4)) == TestEnum.NEWS
-    @test getfield(TestEnum2, lookup(TestEnum2, 5)) == TestEnum.PRODUCTS
-    @test getfield(TestEnum2, lookup(TestEnum2, 6)) == TestEnum.VIDEO
+    @test getproperty(TestEnum2, lookup(TestEnum2, 0)) == TestEnum.UNIVERSAL
+    @test getproperty(TestEnum2, lookup(TestEnum2, 1)) == TestEnum.WEB
+    @test getproperty(TestEnum2, lookup(TestEnum2, 2)) == TestEnum.IMAGES
+    @test getproperty(TestEnum2, lookup(TestEnum2, 3)) == TestEnum.LOCAL
+    @test getproperty(TestEnum2, lookup(TestEnum2, 4)) == TestEnum.NEWS
+    @test getproperty(TestEnum2, lookup(TestEnum2, 5)) == TestEnum.PRODUCTS
+    @test getproperty(TestEnum2, lookup(TestEnum2, 6)) == TestEnum.VIDEO
 
     @test enumstr(TestEnum2, TestEnum2.LOCAL) == "LOCAL"
     @test_throws ErrorException enumstr(TestEnum2, Int32(12))

--- a/test/testmetalock.jl
+++ b/test/testmetalock.jl
@@ -1,0 +1,15 @@
+using ProtoBuf
+import ProtoBuf.meta
+
+function testmetalock()
+    println("testing metadata generation locking...")
+    current_async_safety = ProtoBuf.MetaLock.lck !== nothing
+    for async_safety in (true, false)
+        ProtoBuf.enable_async_safety(async_safety)
+        ProtoBuf.metalock() do 
+            "test with lock enabled $async_safety"
+        end
+    end
+    ProtoBuf.enable_async_safety(current_async_safety)
+    nothing
+end

--- a/test/testmetalock.jl
+++ b/test/testmetalock.jl
@@ -1,15 +1,19 @@
 using ProtoBuf
+using Test
 import ProtoBuf.meta
 
 function testmetalock()
-    println("testing metadata generation locking...")
     current_async_safety = ProtoBuf.MetaLock.lck !== nothing
     for async_safety in (true, false)
         ProtoBuf.enable_async_safety(async_safety)
-        ProtoBuf.metalock() do 
+        str = ProtoBuf.metalock() do
             "test with lock enabled $async_safety"
         end
+        @test endswith(str, string(async_safety))
     end
     ProtoBuf.enable_async_safety(current_async_safety)
-    nothing
+end
+
+@testset "Metadata locking" begin
+    testmetalock()
 end

--- a/test/testprotoc.jl
+++ b/test/testprotoc.jl
@@ -17,7 +17,7 @@ function ensure_stdlib()
 end
 
 if Sys.iswindows()
-    println("testing protobuf compiler plugin not enabled on windows")
+    @info("testing protobuf compiler plugin not enabled on windows")
 else
     test_script = joinpath(@__DIR__, "testprotoc.sh")
     protogen_path = joinpath(@__DIR__, "..", "plugin")
@@ -34,15 +34,15 @@ else
         end
     end
     if isempty(protoc_compilers)
-        println("no protobuf compilers setup for testing compiler plugin, skipping compiler tests.")
+        @info("no protobuf compilers setup for testing compiler plugin, skipping compiler tests.")
     else
-        println("testing protobuf compiler plugin...")
-        is_ci && println("detected CI environment, will enable code coverage...")
+        @info("testing protobuf compiler plugin...")
+        is_ci && @info("detected CI environment, will enable code coverage...")
         for protoc_compiler in protoc_compilers
             modified_env["PROTOC"] = protoc_compiler
             modified_env["PATH"] = path_env
             modified_env["JULIA"] = joinpath(Sys.BINDIR, Base.julia_exename())
-            println("testing protoc compiler plugin with ", protoc_compiler)
+            @info("testing protoc compiler plugin with ", protoc_compiler)
             run(setenv(`$test_script`, modified_env))
         end
 
@@ -56,7 +56,7 @@ else
         for protoc_compiler in protoc_compilers
             # set path to pick up compiler
             ENV["PATH"] = string(dirname(protoc_compiler), ":", pathenv)
-            println("testing ProtoBuf.protoc with ", protoc_compiler)
+            @info("testing ProtoBuf.protoc with ", protoc_compiler)
             run(ProtoBuf.protoc(`-I=$test_protos --julia_out=/tmp $test_proto`))
         end
     end

--- a/test/testprotoc.sh
+++ b/test/testprotoc.sh
@@ -14,7 +14,7 @@ PROTOC_VER=`${PROTOC} --version | cut -d" " -f2 | cut -d"." -f1`
 echo "compiler version $PROTOC_VER"
 
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-JULIA_VER=`${JULIA} -e "(VERSION > v\"0.7-\") && (import Pkg; Pkg.activate(joinpath(ENV[\"SCRIPT_DIR\"], \"..\"))); using InteractiveUtils; versioninfo()" | grep "Julia Version"`
+JULIA_VER=`${JULIA} -e "import Pkg; Pkg.activate(joinpath(ENV[\"SCRIPT_DIR\"], \"..\")); using InteractiveUtils; versioninfo()" | grep "Julia Version"`
 echo $JULIA_VER
 
 ERR=0
@@ -23,8 +23,9 @@ SRC="${DIR}/proto"
 OUT="${DIR}/out"
 WELL_KNOWN_PROTO_SRC="${DIR}/../gen"
 GEN="${PROTOC} --proto_path=${SRC} --proto_path=${WELL_KNOWN_PROTO_SRC} --julia_out=${OUT}"
-CHK="${JULIA} -e '(VERSION > v\"0.7-\") && (import Pkg; Pkg.activate(joinpath(ENV[\"SCRIPT_DIR\"], \"..\")));' -e"
+CHK="${JULIA} -e 'import Pkg; Pkg.activate(joinpath(ENV[\"SCRIPT_DIR\"], \"..\"));' -e"
 mkdir -p ${OUT}
+#export JULIA_PROTOBUF_DEBUG=1
 
 cd ${DIR}
 echo "- t1.proto" && ${GEN} ${SRC}/t1.proto && eval " ${CHK} 'include(\"out/t1_pb.jl\")'"
@@ -63,3 +64,4 @@ then
 fi
 
 exit $ERR
+../plugin/protoc-gen-julia

--- a/test/testprotoc.sh
+++ b/test/testprotoc.sh
@@ -47,10 +47,10 @@ ERR=$(($ERR + $?))
 
 if [ ${PROTOC_VER} -eq "3" ]
 then
-    echo "- map3.proto (as dict)" && ${GEN} ${SRC}/map3.proto && eval " ${CHK} 'include(\"out/map3_pb.jl\"); using Test; @test string(MapTest.types[3].name) == \"Dict\"'"
+    echo "- map3.proto (as dict)" && ${GEN} ${SRC}/map3.proto && eval " ${CHK} 'include(\"out/map3_pb.jl\"); using Test; @test meta(MapTest).ordered[3].jtyp <: Dict'"
     ERR=$(($ERR + $?))
     mv out/map3_pb.jl out/map3_dict_pb.jl
-    echo "- map3.proto (as array)" && JULIA_PROTOBUF_MAP_AS_ARRAY=1 ${GEN} ${SRC}/map3.proto && eval " ${CHK} 'include(\"out/map3_pb.jl\"); using Test; @test string(MapTest.types[3].name) == \"Array\"'"
+    echo "- map3.proto (as array)" && JULIA_PROTOBUF_MAP_AS_ARRAY=1 ${GEN} ${SRC}/map3.proto && eval " ${CHK} 'include(\"out/map3_pb.jl\"); using Test; @test meta(MapTest).ordered[3].jtyp <: Array'"
     ERR=$(($ERR + $?))
     mv out/map3_pb.jl out/map3_array_pb.jl
     echo "- oneof3.proto" && ${GEN} ${SRC}/oneof3.proto && eval " ${CHK} 'include(\"out/oneof3_pb.jl\")'"

--- a/test/testtypevers.jl
+++ b/test/testtypevers.jl
@@ -1,8 +1,6 @@
 using ProtoBuf
 import ProtoBuf.meta
 
-print_hdr(tname) = println("testing $tname...")
-
 mutable struct V1 <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
@@ -116,6 +114,7 @@ function check_V1_v2()
     @test readval == checkval
 end
 
-print_hdr("serialization across type versions")
-check_samestruct()
-check_V1_v2()
+@testset "Serialization across type versions" begin
+    check_samestruct()
+    check_V1_v2()
+end

--- a/test/testtypevers.jl
+++ b/test/testtypevers.jl
@@ -1,59 +1,119 @@
 using ProtoBuf
+import ProtoBuf.meta
 
 print_hdr(tname) = println("testing $tname...")
 
-mutable struct V1
-    f1::Int32
-    f2::Bool
-    V1() = (a=new(); clear(a); a)
-    V1(f1,f2) = new(f1,f2)
+mutable struct V1 <: ProtoType
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function V1(; kwargs...)
+        obj = new(meta(V1), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+const __meta_V1 = Ref{ProtoMeta}()
+function meta(::Type{V1})
+    if !isassigned(__meta_V1)
+        __meta_V1[] = target = ProtoMeta(V1)
+        allflds = Pair{Symbol,Union{Type,String}}[:f1 => Int32, :f2 => Bool]
+        meta(target, V1, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_V1[]
+end
+function Base.getproperty(obj::V1, name::Symbol)
+    if name === :f1
+        return (obj.__protobuf_jl_internal_values[name])::Int32
+    elseif name === :f2
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    else
+        getfield(obj, name)
+    end
 end
 
-mutable struct V2
-    f1::Int64
-    f2::Bool
-    f3::Int64
-    V2() = (a=new(); clear(a); a)
-    V2(f1,f2,f3) = new(f1,f2,f3)
+mutable struct V2 <: ProtoType
+    __protobuf_jl_internal_meta::ProtoMeta
+    __protobuf_jl_internal_values::Dict{Symbol,Any}
+
+    function V2(; kwargs...)
+        obj = new(meta(V2), Dict{Symbol,Any}())
+        values = obj.__protobuf_jl_internal_values
+        symdict = obj.__protobuf_jl_internal_meta.symdict
+        for nv in kwargs
+            fldname, fldval = nv
+            fldtype = symdict[fldname].jtyp
+            (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
+            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+        end
+        obj
+    end
+end
+const __meta_V2 = Ref{ProtoMeta}()
+function meta(::Type{V2})
+    if !isassigned(__meta_V2)
+        __meta_V2[] = target = ProtoMeta(V2)
+        allflds = Pair{Symbol,Union{Type,String}}[:f1 => Int64, :f2 => Bool, :f3 => Int64]
+        meta(target, V2, allflds, ProtoBuf.DEF_REQ, ProtoBuf.DEF_FNUM, ProtoBuf.DEF_VAL, ProtoBuf.DEF_PACK, ProtoBuf.DEF_WTYPES, ProtoBuf.DEF_ONEOFS, ProtoBuf.DEF_ONEOF_NAMES)
+    end
+    __meta_V2[]
+end
+function Base.getproperty(obj::V2, name::Symbol)
+    if name === :f1
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    elseif name === :f2
+        return (obj.__protobuf_jl_internal_values[name])::Bool
+    elseif name === :f3
+        return (obj.__protobuf_jl_internal_values[name])::Int64
+    else
+        getfield(obj, name)
+    end
 end
 
 function check_samestruct()
     iob = PipeBuffer();
-    writeval = V1(1, true);
+    writeval = V1(; f1=1, f2=true);
     writeproto(iob, writeval);
     readval = readproto(iob, V1());
-    @assert ProtoBuf.protoeq(readval, writeval)
+    @test readval == writeval
 
     iob = PipeBuffer();
-    writeval = V2(1, true, 20);
+    writeval = V2(; f1=1, f2=true, f3=20);
     writeproto(iob, writeval);
     readval = readproto(iob, V2());
-    @assert ProtoBuf.protoeq(readval, writeval)
+    @test readval == writeval
 end
 
 # write V1, read V2
 # write V2, read V1
 function check_V1_v2()
     iob = PipeBuffer();
-    writeval = V1(1, true);
+    writeval = V1(; f1=1, f2=true);
     writeproto(iob, writeval);
     readval = readproto(iob, V2());
-    checkval = V2(1,true,0)
-    @assert ProtoBuf.protoeq(readval, checkval)
+    checkval = V2(; f1=1, f2=true, f3=0)
+    @test readval == checkval
 
     iob = PipeBuffer();
-    writeval = V2(1, true, 20);
+    writeval = V2(; f1=1, f2=true, f3=20);
     writeproto(iob, writeval);
     readval = readproto(iob, V1());
-    checkval = V1(1,true)
-    @assert ProtoBuf.protoeq(readval, checkval)
+    checkval = V1(; f1=1, f2=true)
+    @test readval == checkval
 
     iob = PipeBuffer();
-    writeval = V2(typemax(Int64), true, 20);
+    writeval = V2(; f1=typemax(Int64), f2=true, f3=20);
     writeproto(iob, writeval);
     readval = readproto(iob, V1());
-    checkval = V1(-1,true)  # overflow can't be detected as negative int32 is sign extended for serialization
-    @assert ProtoBuf.protoeq(readval, checkval)
+    checkval = V1(; f1=-1, f2=true)  # overflow can't be detected as negative int32 is sign extended for serialization
+    @test readval == checkval
 end
 
 print_hdr("serialization across type versions")

--- a/test/testutilapi.jl
+++ b/test/testutilapi.jl
@@ -3,8 +3,6 @@ using ProtoBuf
 using ..Test
 import ProtoBuf.meta
 
-print_hdr(tname) = println("testing $tname...")
-
 mutable struct TestType <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
@@ -80,6 +78,7 @@ end
 
 end # module ProtoBufTestApis
 
-print_hdr("utility api methods")
-ProtoBufTestApis.test_apis()
-ProtoBufTestApis.test_deepcopy()
+@testset "Utility APIs" begin
+    ProtoBufTestApis.test_apis()
+    ProtoBufTestApis.test_deepcopy()
+end

--- a/test/testwellknown.jl
+++ b/test/testwellknown.jl
@@ -4,52 +4,53 @@ using ProtoBuf.google.protobuf
 using ..Test
 using Random
 
-print_hdr(tname) = println("testing $tname...")
-
 function test_listvalue()
-    print_hdr(ListValue.name)
-    v1 = Value(;number_value=10.10)
-    v2 = Value(;string_value="hello")
-    va = [v1, v2]
-    l = ListValue(;values=va)
-    iob = PipeBuffer()
-    writeproto(iob, l)
-    l1 = ListValue()
-    readproto(iob, l1)
+    @testset "$(ListValue.name)" begin
+        v1 = Value(;number_value=10.10)
+        v2 = Value(;string_value="hello")
+        va = [v1, v2]
+        l = ListValue(;values=va)
+        iob = PipeBuffer()
+        writeproto(iob, l)
+        l1 = ListValue()
+        readproto(iob, l1)
 
-    @test length(l.values) == length(l1.values)
-    @test l.values[1].number_value == l1.values[1].number_value
-    @test l.values[2].string_value == l1.values[2].string_value
-    @test l == l1
+        @test length(l.values) == length(l1.values)
+        @test l.values[1].number_value == l1.values[1].number_value
+        @test l.values[2].string_value == l1.values[2].string_value
+        @test l == l1
+    end
 end
 
 function test_struct()
-    print_hdr(Struct.name)
-    v1 = Value(;number_value=10.10)
-    v2 = Value(;string_value="hello")
-    vd = Dict{AbstractString,Any}()
-    vd["v1"] = v1
-    vd["v2"] = v2
-    s = Struct(;fields=vd)
-    iob = PipeBuffer()
-    writeproto(iob, s)
-    s1 = Struct()
-    readproto(iob, s1)
+    @testset "$(Struct.name)" begin
+        v1 = Value(;number_value=10.10)
+        v2 = Value(;string_value="hello")
+        vd = Dict{AbstractString,Any}()
+        vd["v1"] = v1
+        vd["v2"] = v2
+        s = Struct(;fields=vd)
+        iob = PipeBuffer()
+        writeproto(iob, s)
+        s1 = Struct()
+        readproto(iob, s1)
 
-    @test length(s.fields) == length(s1.fields)
-    @test s.fields["v1"].number_value == s1.fields["v1"].number_value
-    @test s.fields["v2"].string_value == s1.fields["v2"].string_value
-    @test s == s1
+        @test length(s.fields) == length(s1.fields)
+        @test s.fields["v1"].number_value == s1.fields["v1"].number_value
+        @test s.fields["v2"].string_value == s1.fields["v2"].string_value
+        @test s == s1
+    end
 end
 
 function test_generic(::Type{T}; kwargs...) where T
-    print_hdr(T.name)
-    w = T(;kwargs...)
-    iob = PipeBuffer()
-    writeproto(iob, w)
-    r = T()
-    readproto(iob, r)
-    @test w == r
+    @testset "$(T.name)" begin
+        w = T(;kwargs...)
+        iob = PipeBuffer()
+        writeproto(iob, w)
+        r = T()
+        readproto(iob, r)
+        @test w == r
+    end
 end
 
 test_any() = test_generic(_Any; type_url="testurl", value=UInt8[1,2,3,4,5])
@@ -68,11 +69,13 @@ end
 
 end # module ProtoBufTestWellKnown
 
-ProtoBufTestWellKnown.test_listvalue()
-ProtoBufTestWellKnown.test_struct()
-ProtoBufTestWellKnown.test_any()
-ProtoBufTestWellKnown.test_empty()
-ProtoBufTestWellKnown.test_timestamp()
-ProtoBufTestWellKnown.test_duration()
-ProtoBufTestWellKnown.test_fieldmask()
-ProtoBufTestWellKnown.test_wrappers()
+@testset "Wellknown types" begin
+    ProtoBufTestWellKnown.test_listvalue()
+    ProtoBufTestWellKnown.test_struct()
+    ProtoBufTestWellKnown.test_any()
+    ProtoBufTestWellKnown.test_empty()
+    ProtoBufTestWellKnown.test_timestamp()
+    ProtoBufTestWellKnown.test_duration()
+    ProtoBufTestWellKnown.test_fieldmask()
+    ProtoBufTestWellKnown.test_wrappers()
+end


### PR DESCRIPTION
- Updated generated code to use get/set properties and not use any globals to keep state. Protobuf struct metadata access are thread safe now.
- Enums are generated as NamedTuples instead of custom structs. Makes them simpler to use.
- Added code generator flag to have it log julia protoc debug messages to file
- Dropped a few unused and now unnecessary exported methods
- Reorganized tests into testsets, reduced unnecessary outputs

Most of the book-keeping data for a protobuf struct is now kept inside the struct instance. So that does not hinder thread safe usage. However struct instances themselves need to be locked if they are being read and written to from different threads, as is expected of any regular Julia struct.

Protobuf metadata for a struct (the information about fields and their properties as mentioned in the protobuf IDL definition) however is best initialized once and reused. It was not possible to generate code in such a way that it could be initialized when code is loaded and pre-compiled. This was because of the need to support nested and recursive struct references that protobuf allows - metadata for a struct could be defined only after the struct and all of its dependencies were defined. Metadata initialization is deferred to the first constructor call and is cached for reuse. That needs locking to make access to it thread safe, but the cost of that should be small and the benefits of caching should outweigh that in most cases.

But it is possible to eliminate the locking overhead altogether, it needs a bit of initialization to be done. The way to do it would be to call the constructors of all protobuf structs one wishes to use first and then switch the locking off by calling `ProtoBuf.enable_async_safety(false)`. This would allow the already initialized metatada to be used without any further overhead of locking. This can also be set to `false` for a single threaded synchronous applications.

fixes #140 