### PR TITLE
add hasproperty for Julia < 1.2 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 keywords = ["protobuf", "protoc"]
 license = "MIT"
 desc = "Julia protobuf implementation"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -1,6 +1,12 @@
 module ProtoBuf
 
-import Base: setproperty!, getproperty, hasproperty, propertynames, show, copy!, deepcopy, hash, isequal, ==
+import Base: setproperty!, getproperty, propertynames, show, copy!, deepcopy, hash, isequal, ==
+
+if VERSION < v"1.2.0-DEV.272"
+    hasproperty(x, s::Symbol) = s in propertynames(x)
+else
+    import Base: hasproperty
+end
 
 export writeproto, readproto, ProtoMeta, ProtoMetaAttribs, meta
 export isfilled, which_oneof


### PR DESCRIPTION
ProtoBuf uses Base.hasproperty, however this was introduced in Julia 1.2.
This adds `hasproperty` for Julia versions < 1.2.
Also bumped version to v0.9.1 in preparation for tagging.

fixes #147