### PR TITLE
track default values, fix oneof code generation

### DIFF
--- a/src/codec.jl
+++ b/src/codec.jl
@@ -547,6 +547,7 @@ function setdefaultproperties!(obj::ProtoType, meta::ProtoMeta=meta(typeof(obj))
             default = attrib.default[1]
             setproperty!(obj, fld, convert(attrib.jtyp, deepcopy(default)))
             @debug("readproto set default", typ=typeof(obj), fld, default)
+            _markdefaultproperty!(obj, fld)
         end
     end
     obj
@@ -680,10 +681,13 @@ function setproperty!(obj::ProtoType, fld::Symbol, val)
         _unset_oneof(obj, objmeta, fld)
         fldtype = symdict[fld].jtyp
         obj.__protobuf_jl_internal_values[fld] = isa(val, fldtype) ? val : convert(fldtype, val)
+        delete!(obj.__protobuf_jl_internal_defaultset, fld)
     else
         setfield!(obj, fld, val)
     end
 end
+_markdefaultproperty!(obj::ProtoType, fld::Symbol) = push!(obj.__protobuf_jl_internal_defaultset, fld)
+isdefaultproperty(obj::ProtoType, fld::Symbol) = fld in obj.__protobuf_jl_internal_defaultset
 
 function clear(obj::ProtoType)
     empty!(obj.__protobuf_jl_internal_values)

--- a/src/gen.jl
+++ b/src/gen.jl
@@ -349,7 +349,7 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
     if hasproperty(dtype, :field)
         for fld_idx in 1:length(dtype.field)
             field = dtype.field[fld_idx]
-            if hasproperty(field, :oneof_index) && !isempty(oneofs)
+            if hasproperty(field, :oneof_index) && !isempty(oneofs) && !ProtoBuf.isdefaultproperty(field, :oneof_index)
                 oneof_idx = field.oneof_index + 1
                 oneofs[fld_idx] = oneof_idx
             end
@@ -468,9 +468,10 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
         mutable struct $(dtypename) <: ProtoType
             __protobuf_jl_internal_meta::ProtoMeta
             __protobuf_jl_internal_values::Dict{Symbol,Any}
+            __protobuf_jl_internal_defaultset::Set{Symbol}
 
             function $(dtypename)(; kwargs...)
-                obj = new(meta($(dtypename)), Dict{Symbol,Any}())
+                obj = new(meta($(dtypename)), Dict{Symbol,Any}(), Set{Symbol}())
                 values = obj.__protobuf_jl_internal_values
                 symdict = obj.__protobuf_jl_internal_meta.symdict
                 for nv in kwargs

--- a/src/google/any_pb.jl
+++ b/src/google/any_pb.jl
@@ -2,9 +2,10 @@
 mutable struct _Any <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function _Any(; kwargs...)
-        obj = new(meta(_Any), Dict{Symbol,Any}())
+        obj = new(meta(_Any), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/api_pb.jl
+++ b/src/google/api_pb.jl
@@ -2,9 +2,10 @@
 mutable struct Method <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Method(; kwargs...)
-        obj = new(meta(Method), Dict{Symbol,Any}())
+        obj = new(meta(Method), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -50,9 +51,10 @@ end
 mutable struct Mixin <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Mixin(; kwargs...)
-        obj = new(meta(Mixin), Dict{Symbol,Any}())
+        obj = new(meta(Mixin), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -88,9 +90,10 @@ end
 mutable struct Api <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Api(; kwargs...)
-        obj = new(meta(Api), Dict{Symbol,Any}())
+        obj = new(meta(Api), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/descriptor_pb.jl
+++ b/src/google/descriptor_pb.jl
@@ -2,9 +2,10 @@
 mutable struct UninterpretedOption_NamePart <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function UninterpretedOption_NamePart(; kwargs...)
-        obj = new(meta(UninterpretedOption_NamePart), Dict{Symbol,Any}())
+        obj = new(meta(UninterpretedOption_NamePart), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -41,9 +42,10 @@ end
 mutable struct UninterpretedOption <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function UninterpretedOption(; kwargs...)
-        obj = new(meta(UninterpretedOption), Dict{Symbol,Any}())
+        obj = new(meta(UninterpretedOption), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -102,9 +104,10 @@ const FieldOptions_JSType = (;[
 mutable struct FieldOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function FieldOptions(; kwargs...)
-        obj = new(meta(FieldOptions), Dict{Symbol,Any}())
+        obj = new(meta(FieldOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -152,9 +155,10 @@ end
 mutable struct MessageOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function MessageOptions(; kwargs...)
-        obj = new(meta(MessageOptions), Dict{Symbol,Any}())
+        obj = new(meta(MessageOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -198,9 +202,10 @@ end
 mutable struct EnumOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function EnumOptions(; kwargs...)
-        obj = new(meta(EnumOptions), Dict{Symbol,Any}())
+        obj = new(meta(EnumOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -240,9 +245,10 @@ end
 mutable struct ExtensionRangeOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function ExtensionRangeOptions(; kwargs...)
-        obj = new(meta(ExtensionRangeOptions), Dict{Symbol,Any}())
+        obj = new(meta(ExtensionRangeOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -283,9 +289,10 @@ const MethodOptions_IdempotencyLevel = (;[
 mutable struct MethodOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function MethodOptions(; kwargs...)
-        obj = new(meta(MethodOptions), Dict{Symbol,Any}())
+        obj = new(meta(MethodOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -331,9 +338,10 @@ const FileOptions_OptimizeMode = (;[
 mutable struct FileOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function FileOptions(; kwargs...)
-        obj = new(meta(FileOptions), Dict{Symbol,Any}())
+        obj = new(meta(FileOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -409,9 +417,10 @@ end
 mutable struct EnumValueOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function EnumValueOptions(; kwargs...)
-        obj = new(meta(EnumValueOptions), Dict{Symbol,Any}())
+        obj = new(meta(EnumValueOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -449,9 +458,10 @@ end
 mutable struct OneofOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function OneofOptions(; kwargs...)
-        obj = new(meta(OneofOptions), Dict{Symbol,Any}())
+        obj = new(meta(OneofOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -486,9 +496,10 @@ end
 mutable struct ServiceOptions <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function ServiceOptions(; kwargs...)
-        obj = new(meta(ServiceOptions), Dict{Symbol,Any}())
+        obj = new(meta(ServiceOptions), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -553,9 +564,10 @@ const FieldDescriptorProto_Label = (;[
 mutable struct FieldDescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function FieldDescriptorProto(; kwargs...)
-        obj = new(meta(FieldDescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(FieldDescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -608,9 +620,10 @@ end
 mutable struct DescriptorProto_ExtensionRange <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function DescriptorProto_ExtensionRange(; kwargs...)
-        obj = new(meta(DescriptorProto_ExtensionRange), Dict{Symbol,Any}())
+        obj = new(meta(DescriptorProto_ExtensionRange), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -648,9 +661,10 @@ end
 mutable struct MethodDescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function MethodDescriptorProto(; kwargs...)
-        obj = new(meta(MethodDescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(MethodDescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -695,9 +709,10 @@ end
 mutable struct EnumValueDescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function EnumValueDescriptorProto(; kwargs...)
-        obj = new(meta(EnumValueDescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(EnumValueDescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -735,9 +750,10 @@ end
 mutable struct EnumDescriptorProto_EnumReservedRange <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function EnumDescriptorProto_EnumReservedRange(; kwargs...)
-        obj = new(meta(EnumDescriptorProto_EnumReservedRange), Dict{Symbol,Any}())
+        obj = new(meta(EnumDescriptorProto_EnumReservedRange), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -773,9 +789,10 @@ end
 mutable struct EnumDescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function EnumDescriptorProto(; kwargs...)
-        obj = new(meta(EnumDescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(EnumDescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -817,9 +834,10 @@ end
 mutable struct OneofDescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function OneofDescriptorProto(; kwargs...)
-        obj = new(meta(OneofDescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(OneofDescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -855,9 +873,10 @@ end
 mutable struct DescriptorProto_ReservedRange <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function DescriptorProto_ReservedRange(; kwargs...)
-        obj = new(meta(DescriptorProto_ReservedRange), Dict{Symbol,Any}())
+        obj = new(meta(DescriptorProto_ReservedRange), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -893,9 +912,10 @@ end
 mutable struct DescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function DescriptorProto(; kwargs...)
-        obj = new(meta(DescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(DescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -948,9 +968,10 @@ end
 mutable struct ServiceDescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function ServiceDescriptorProto(; kwargs...)
-        obj = new(meta(ServiceDescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(ServiceDescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -988,9 +1009,10 @@ end
 mutable struct SourceCodeInfo_Location <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function SourceCodeInfo_Location(; kwargs...)
-        obj = new(meta(SourceCodeInfo_Location), Dict{Symbol,Any}())
+        obj = new(meta(SourceCodeInfo_Location), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -1034,9 +1056,10 @@ end
 mutable struct SourceCodeInfo <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function SourceCodeInfo(; kwargs...)
-        obj = new(meta(SourceCodeInfo), Dict{Symbol,Any}())
+        obj = new(meta(SourceCodeInfo), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -1070,9 +1093,10 @@ end
 mutable struct FileDescriptorProto <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function FileDescriptorProto(; kwargs...)
-        obj = new(meta(FileDescriptorProto), Dict{Symbol,Any}())
+        obj = new(meta(FileDescriptorProto), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -1129,9 +1153,10 @@ end
 mutable struct FileDescriptorSet <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function FileDescriptorSet(; kwargs...)
-        obj = new(meta(FileDescriptorSet), Dict{Symbol,Any}())
+        obj = new(meta(FileDescriptorSet), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -1165,9 +1190,10 @@ end
 mutable struct GeneratedCodeInfo_Annotation <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function GeneratedCodeInfo_Annotation(; kwargs...)
-        obj = new(meta(GeneratedCodeInfo_Annotation), Dict{Symbol,Any}())
+        obj = new(meta(GeneratedCodeInfo_Annotation), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -1208,9 +1234,10 @@ end
 mutable struct GeneratedCodeInfo <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function GeneratedCodeInfo(; kwargs...)
-        obj = new(meta(GeneratedCodeInfo), Dict{Symbol,Any}())
+        obj = new(meta(GeneratedCodeInfo), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/duration_pb.jl
+++ b/src/google/duration_pb.jl
@@ -2,9 +2,10 @@
 mutable struct Duration <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Duration(; kwargs...)
-        obj = new(meta(Duration), Dict{Symbol,Any}())
+        obj = new(meta(Duration), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/empty_pb.jl
+++ b/src/google/empty_pb.jl
@@ -2,9 +2,10 @@
 mutable struct Empty <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Empty(; kwargs...)
-        obj = new(meta(Empty), Dict{Symbol,Any}())
+        obj = new(meta(Empty), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/field_mask_pb.jl
+++ b/src/google/field_mask_pb.jl
@@ -2,9 +2,10 @@
 mutable struct FieldMask <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function FieldMask(; kwargs...)
-        obj = new(meta(FieldMask), Dict{Symbol,Any}())
+        obj = new(meta(FieldMask), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/plugin_pb.jl
+++ b/src/google/plugin_pb.jl
@@ -2,9 +2,10 @@
 mutable struct Version <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Version(; kwargs...)
-        obj = new(meta(Version), Dict{Symbol,Any}())
+        obj = new(meta(Version), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -44,9 +45,10 @@ end
 mutable struct CodeGeneratorRequest <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function CodeGeneratorRequest(; kwargs...)
-        obj = new(meta(CodeGeneratorRequest), Dict{Symbol,Any}())
+        obj = new(meta(CodeGeneratorRequest), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -87,9 +89,10 @@ end
 mutable struct CodeGeneratorResponse_File <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function CodeGeneratorResponse_File(; kwargs...)
-        obj = new(meta(CodeGeneratorResponse_File), Dict{Symbol,Any}())
+        obj = new(meta(CodeGeneratorResponse_File), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -128,9 +131,10 @@ end
 mutable struct CodeGeneratorResponse <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function CodeGeneratorResponse(; kwargs...)
-        obj = new(meta(CodeGeneratorResponse), Dict{Symbol,Any}())
+        obj = new(meta(CodeGeneratorResponse), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/source_context_pb.jl
+++ b/src/google/source_context_pb.jl
@@ -2,9 +2,10 @@
 mutable struct SourceContext <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function SourceContext(; kwargs...)
-        obj = new(meta(SourceContext), Dict{Symbol,Any}())
+        obj = new(meta(SourceContext), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/struct_pb.jl
+++ b/src/google/struct_pb.jl
@@ -6,9 +6,10 @@ const NullValue = (;[
 mutable struct Struct_FieldsEntry <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Struct_FieldsEntry(; kwargs...)
-        obj = new(meta(Struct_FieldsEntry), Dict{Symbol,Any}())
+        obj = new(meta(Struct_FieldsEntry), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -44,9 +45,10 @@ end
 mutable struct Struct <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Struct(; kwargs...)
-        obj = new(meta(Struct), Dict{Symbol,Any}())
+        obj = new(meta(Struct), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -80,9 +82,10 @@ end
 mutable struct Value <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Value(; kwargs...)
-        obj = new(meta(Value), Dict{Symbol,Any}())
+        obj = new(meta(Value), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -128,9 +131,10 @@ end
 mutable struct ListValue <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function ListValue(; kwargs...)
-        obj = new(meta(ListValue), Dict{Symbol,Any}())
+        obj = new(meta(ListValue), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/timestamp_pb.jl
+++ b/src/google/timestamp_pb.jl
@@ -2,9 +2,10 @@
 mutable struct Timestamp <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Timestamp(; kwargs...)
-        obj = new(meta(Timestamp), Dict{Symbol,Any}())
+        obj = new(meta(Timestamp), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/type_pb.jl
+++ b/src/google/type_pb.jl
@@ -7,9 +7,10 @@ const Syntax = (;[
 mutable struct Option <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Option(; kwargs...)
-        obj = new(meta(Option), Dict{Symbol,Any}())
+        obj = new(meta(Option), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -45,9 +46,10 @@ end
 mutable struct EnumValue <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function EnumValue(; kwargs...)
-        obj = new(meta(EnumValue), Dict{Symbol,Any}())
+        obj = new(meta(EnumValue), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -114,9 +116,10 @@ const Field_Cardinality = (;[
 mutable struct Field <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Field(; kwargs...)
-        obj = new(meta(Field), Dict{Symbol,Any}())
+        obj = new(meta(Field), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -169,9 +172,10 @@ end
 mutable struct _Enum <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function _Enum(; kwargs...)
-        obj = new(meta(_Enum), Dict{Symbol,Any}())
+        obj = new(meta(_Enum), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -213,9 +217,10 @@ end
 mutable struct _Type <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function _Type(; kwargs...)
-        obj = new(meta(_Type), Dict{Symbol,Any}())
+        obj = new(meta(_Type), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/src/google/wrappers_pb.jl
+++ b/src/google/wrappers_pb.jl
@@ -2,9 +2,10 @@
 mutable struct DoubleValue <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function DoubleValue(; kwargs...)
-        obj = new(meta(DoubleValue), Dict{Symbol,Any}())
+        obj = new(meta(DoubleValue), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -38,9 +39,10 @@ end
 mutable struct FloatValue <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function FloatValue(; kwargs...)
-        obj = new(meta(FloatValue), Dict{Symbol,Any}())
+        obj = new(meta(FloatValue), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -74,9 +76,10 @@ end
 mutable struct Int64Value <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Int64Value(; kwargs...)
-        obj = new(meta(Int64Value), Dict{Symbol,Any}())
+        obj = new(meta(Int64Value), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -110,9 +113,10 @@ end
 mutable struct UInt64Value <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function UInt64Value(; kwargs...)
-        obj = new(meta(UInt64Value), Dict{Symbol,Any}())
+        obj = new(meta(UInt64Value), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -146,9 +150,10 @@ end
 mutable struct Int32Value <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function Int32Value(; kwargs...)
-        obj = new(meta(Int32Value), Dict{Symbol,Any}())
+        obj = new(meta(Int32Value), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -182,9 +187,10 @@ end
 mutable struct UInt32Value <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function UInt32Value(; kwargs...)
-        obj = new(meta(UInt32Value), Dict{Symbol,Any}())
+        obj = new(meta(UInt32Value), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -218,9 +224,10 @@ end
 mutable struct BoolValue <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function BoolValue(; kwargs...)
-        obj = new(meta(BoolValue), Dict{Symbol,Any}())
+        obj = new(meta(BoolValue), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -254,9 +261,10 @@ end
 mutable struct StringValue <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function StringValue(; kwargs...)
-        obj = new(meta(StringValue), Dict{Symbol,Any}())
+        obj = new(meta(StringValue), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -290,9 +298,10 @@ end
 mutable struct BytesValue <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function BytesValue(; kwargs...)
-        obj = new(meta(BytesValue), Dict{Symbol,Any}())
+        obj = new(meta(BytesValue), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/test/services/testsvc.jl
+++ b/test/services/testsvc.jl
@@ -26,9 +26,10 @@ close(channel::TestRpcChannel) = close(channel.sock)
 mutable struct SvcHeader <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function SvcHeader(; kwargs...)
-        obj = new(meta(SvcHeader), Dict{Symbol,Any}())
+        obj = new(meta(SvcHeader), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/test/services/testsvc_pb.jl
+++ b/test/services/testsvc_pb.jl
@@ -5,9 +5,10 @@ import ProtoBuf.meta
 mutable struct BinaryOpReq <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function BinaryOpReq(; kwargs...)
-        obj = new(meta(BinaryOpReq), Dict{Symbol,Any}())
+        obj = new(meta(BinaryOpReq), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -36,9 +37,10 @@ end
 mutable struct BinaryOpResp <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function BinaryOpResp(; kwargs...)
-        obj = new(meta(BinaryOpResp), Dict{Symbol,Any}())
+        obj = new(meta(BinaryOpResp), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/test/testcodec.jl
+++ b/test/testcodec.jl
@@ -17,9 +17,10 @@ const TestTypePack = Ref{Vector{Symbol}}(ProtoBuf.DEF_PACK)
 mutable struct TestType <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestType(; kwargs...)
-        obj = new(meta(TestType), Dict{Symbol,Any}())
+        obj = new(meta(TestType), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -47,9 +48,10 @@ end
 mutable struct TestStr <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestStr(; kwargs...)
-        obj = new(meta(TestStr), Dict{Symbol,Any}())
+        obj = new(meta(TestStr), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -76,9 +78,10 @@ end
 mutable struct TestOptional <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestOptional(; kwargs...)
-        obj = new(meta(TestOptional), Dict{Symbol,Any}())
+        obj = new(meta(TestOptional), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -110,9 +113,10 @@ end
 mutable struct TestNested <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestNested(; kwargs...)
-        obj = new(meta(TestNested), Dict{Symbol,Any}())
+        obj = new(meta(TestNested), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -145,9 +149,10 @@ end
 mutable struct TestDefaults <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestDefaults(; kwargs...)
-        obj = new(meta(TestDefaults), Dict{Symbol,Any}())
+        obj = new(meta(TestDefaults), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -179,9 +184,10 @@ end
 mutable struct TestOneofs <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestOneofs(; kwargs...)
-        obj = new(meta(TestOneofs), Dict{Symbol,Any}())
+        obj = new(meta(TestOneofs), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -214,9 +220,10 @@ end
 mutable struct TestMaps <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestMaps(; kwargs...)
-        obj = new(meta(TestMaps), Dict{Symbol,Any}())
+        obj = new(meta(TestMaps), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -247,9 +254,10 @@ end
 mutable struct TestFilled <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestFilled(; kwargs...)
-        obj = new(meta(TestFilled), Dict{Symbol,Any}())
+        obj = new(meta(TestFilled), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/test/testtypevers.jl
+++ b/test/testtypevers.jl
@@ -4,9 +4,10 @@ import ProtoBuf.meta
 mutable struct V1 <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function V1(; kwargs...)
-        obj = new(meta(V1), Dict{Symbol,Any}())
+        obj = new(meta(V1), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs
@@ -40,9 +41,10 @@ end
 mutable struct V2 <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function V2(; kwargs...)
-        obj = new(meta(V2), Dict{Symbol,Any}())
+        obj = new(meta(V2), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs

--- a/test/testutilapi.jl
+++ b/test/testutilapi.jl
@@ -6,9 +6,10 @@ import ProtoBuf.meta
 mutable struct TestType <: ProtoType
     __protobuf_jl_internal_meta::ProtoMeta
     __protobuf_jl_internal_values::Dict{Symbol,Any}
+    __protobuf_jl_internal_defaultset::Set{Symbol}
 
     function TestType(; kwargs...)
-        obj = new(meta(TestType), Dict{Symbol,Any}())
+        obj = new(meta(TestType), Dict{Symbol,Any}(), Set{Symbol}())
         values = obj.__protobuf_jl_internal_values
         symdict = obj.__protobuf_jl_internal_meta.symdict
         for nv in kwargs


### PR DESCRIPTION
We need to keep track of whether a field value has been set from the message or because of the default value rule. This is required to be able to generate code for structs having `oneof` fields among other fields.

fixes: #146