### PR TITLE
use getfield instead of eval to get service method

### DIFF
--- a/src/svc.jl
+++ b/src/svc.jl
@@ -71,7 +71,7 @@ get_descriptor_for_type(svc::ProtoService) = svc.desc
 call_method(svc::ProtoService, meth::MethodDescriptor, controller::ProtoRpcController, request, done::Function) = @async done(call_method(svc, meth, controller, request))
 function call_method(svc::ProtoService, meth::MethodDescriptor, controller::ProtoRpcController, request)
     meth_desc = find_method(svc, meth)
-    m = Core.eval(svc.impl_module, Symbol(meth_desc.name))
+    m = getfield(svc.impl_module, Symbol(meth_desc.name))
     isa(request, meth_desc.input_type) || throw(ProtoServiceException("Invalid input type $(typeof(request)) for service $(meth_desc.name). Expected type $(meth_desc.input_type)"))
     m(request)
 end


### PR DESCRIPTION
We are directly fetching a symbol from module and `getfield` is more efficient than `eval` for this purpose as pointed out in #156.

fixes #156