### PR TITLE
Attempt to instantiate before calling ProtoBuf to ensure environment has

### DIFF
--- a/plugin/protoc-gen-julia
+++ b/plugin/protoc-gen-julia
@@ -20,7 +20,7 @@ if [ ${JULIA_PROTOBUF_DEBUG:-0} -eq 1 ]; then
 fi
 
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-JULIA_GEN="${JULIA} ${COVERAGE} --project=${SCRIPT_DIR}/.. -e 'using ProtoBuf; using ProtoBuf.Gen; gen()'"
+JULIA_GEN="${JULIA} ${COVERAGE} --project=${SCRIPT_DIR}/.. -e 'using Pkg; Pkg.instantiate(); using ProtoBuf; using ProtoBuf.Gen; gen()'"
 if [ -z "${FLAGS}" ]
 then
     eval " ${JULIA_GEN}"

--- a/plugin/protogen.jl
+++ b/plugin/protogen.jl
@@ -1,3 +1,4 @@
+using Pkg; Pkg.instantiate()
 using ProtoBuf
 using ProtoBuf.Gen
 gen()


### PR DESCRIPTION
correct protoc_jll installed

Without this, I kept getting errors that `protoc_jll` wasn't installed in the current environment.