### PR TITLE
correct codegen for nested protobuf structs

### DIFF
--- a/test/proto/t2.proto
+++ b/test/proto/t2.proto
@@ -11,3 +11,7 @@ message MA {
 message MC {
   required string c = 1;
 }
+
+service TestServicePkgP {
+  rpc Method1(MA.MB) returns(MC);
+}


### PR DESCRIPTION
Nested structs are allowed in proto definition. In Julia nested structs are generated as separate structs with names flattened out using `_` as separator.

E.g. with a proto file definition:

```
...
message MA {
  required string a = 1;
  optional MB b = 2;
  message MB {
    optional MC c = 1;
  }
}
...
service TestServicePkgP {
  rpc Method1(MA.MB) returns(MC);
}
```

The service method `Method1` generated will have the input type `MA_MB`.
```
mutable struct MA_MB <: ProtoType
...
end
...
Method1(stub::TestServicePkgPBlockingStub, controller::ProtoRpcController, inp::MA_MB)
```

That was incorrectly generated as `MA.MB` earlier, which this PR fixes.

fixes #167 