### PR TITLE
Ignore nothing when setting a field

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -478,7 +478,9 @@ function generate_msgtype(outio::IO, errio::IO, dtype::DescriptorProto, scope::S
                     fldname, fldval = nv
                     fldtype = symdict[fldname].jtyp
                     (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
-                    values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+                    if fldval !== nothing
+                        values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+                    end
                 end
                 obj
             end""")


### PR DESCRIPTION
This feature would allow me to create protobuf objects more easily. Rather than constructing the object in different ways, I can pass a field value that is possibly unavailable and the code just ignores it. For example, from plugin.proto:

```julia
# I want this to work regardless of whether `error` is `nothing` or not
CodeGeneratorResponse(; error)
```

Currently, I would have to write something like:
```julia
if error === nothing
    CodeGeneratorResponse()
else
    CodeGeneratorResponse(; error)
end
```

Or I would have to write:
```julia
r = CodeGeneratorResponse()
if error !== nothing
    r.error = r
end
```

The issue is that the code becomes clumsy very quickly when 
1. I have to deal with more fields like that 
2. I have to work this way for nested structs
