### PR TITLE
Remove indexing-lookup that cancel each other

### DIFF
--- a/src/codec.jl
+++ b/src/codec.jl
@@ -662,7 +662,7 @@ function _unset_oneof(obj, objmeta, fld)
         end
         nameidx = objmeta.oneofs[fldidx]
         if nameidx > 0
-            oneofprop = which_oneof(obj, objmeta.oneof_names[nameidx])
+            oneofprop = _which_oneof(obj, objmeta, nameidx)
             (oneofprop === Symbol()) || clear(obj, oneofprop)
         end
     end


### PR DESCRIPTION
Currently, the code has the index, it computes the name with `objmeta.oneof_names[nameidx]` and then find the index from the name in `which_oneof` (which is the same index as what we had at the beginning, isn't it ?) and ends up calling `_which_oneof`.
In this PR, this is changed to directly call `_which_oneof`.