### PR TITLE
Specialize on type for large performance gains

### DIFF
--- a/src/codec.jl
+++ b/src/codec.jl
@@ -432,7 +432,7 @@ function writeproto(io::IO, obj, meta::ProtoMeta=meta(typeof(obj)))
     n
 end
 
-function read_lendelim_packed(io, fld, reader, jtyp::Type)
+function read_lendelim_packed(io, fld::Vector{jtyp}, reader) where {jtyp}
     iob = IOBuffer(read_bytes(io))
     while !eof(iob)
         val = reader(iob, jtyp)
@@ -485,7 +485,7 @@ function read_field(io, container, attrib::ProtoMetaAttribs, wiretyp, jtyp_speci
         # Only repeated fields of primitive numeric types (isbitstype == true) can be declared "packed".
         # Maps can not be repeated
         if isbitstype(jtyp) && (wiretyp == WIRETYP_LENDELIM)
-            read_lendelim_packed(io, arr_val, rfn, jtyp)
+            read_lendelim_packed(io, arr_val, rfn)
         elseif ptyp === :obj
             push!(arr_val, read_lendelim_obj(io, instantiate(jtyp), attrib.meta, rfn))
         else


### PR DESCRIPTION
When reading `andora.osm.pbf` with OpenStreetMapX, the timing is:
Before this PR:
```jl
julia> @time OpenStreetMapX.parsePBF("/home/blegat/Downloads/andorra-latest.osm.pbf");
  0.819850 seconds (1.58 M allocations: 183.134 MiB, 17.31% gc time)
```
After ProtoBuf PR:
```jl
julia> @time OpenStreetMapX.parsePBF("/home/blegat/Downloads/andorra-latest.osm.pbf");
  0.358973 seconds (1.14 M allocations: 176.507 MiB, 16.71% gc time)
```
So we get more than 2x speedup. The reason is that Julia is not specializing on `jtyp` hence I think the method lookup `reader(iob, jtyp)` is done at runtime instead of compilation time.