### PR TITLE
Add Set as a keyword

### DIFF
--- a/src/gen.jl
+++ b/src/gen.jl
@@ -67,7 +67,7 @@ const _keywords = [
     "ccall", "finally", "typealias", "break", "continue", "type",
     "global", "module", "using", "import", "export", "const", "let",
     "bitstype", "do", "baremodule", "importall", "immutable",
-    "Type", "Enum", "Any", "DataType", "Base"
+    "Type", "Enum", "Any", "DataType", "Base", "Set"
 ]
 
 chk_keyword(name) = (name in _keywords) ? string('_', name) : String(name)


### PR DESCRIPTION
`Set` can end up being used as a name by schemas, which then causes the generated code to error out when loaded. This change adds `Set` as a known keyword to be mangled into `_Set` to avoid this issue, similarly to how other types in Base are handled.