### PR TITLE
Allow storing unknown enum values

### DIFF
--- a/src/codec/decode.jl
+++ b/src/codec/decode.jl
@@ -26,7 +26,7 @@ end
 decode(d::AbstractProtoDecoder, ::Type{Bool}) = Bool(read(d.io, UInt8))
 function decode(d::AbstractProtoDecoder, ::Type{T}) where {T <: Union{Enum{Int32},Enum{UInt32}}}
     val = vbyte_decode(d.io, UInt32)
-    return val in keys(Base.Enums.namemap(T)) ? T(val) : T(0)
+    return Core.bitcast(T, reinterpret(Int32, val))
 end
 decode(d::AbstractProtoDecoder, ::Type{T}) where {T <: Union{Float64,Float32}} = read(d.io, T)
 function decode!(d::AbstractProtoDecoder, buffer::Dict{K,V}) where {K,V<:_ScalarTypesEnum}

--- a/test/test_decode.jl
+++ b/test/test_decode.jl
@@ -298,6 +298,10 @@ end
         @testset "enum" begin
             test_decode([0x02], TestEnum.C)
         end
+
+        @testset "unknown enum member" begin
+            test_decode([0x10], Core.bitcast(TestEnum.T, Int32(0x10)))
+        end
     end
 
     @testset "fixed" begin


### PR DESCRIPTION
Until now, when we encountered an unknown enum member, we pretended that we got the default value. This is not very useful and could lead to a lot of confusion. This is what the [spec](https://developers.google.com/protocol-buffers/docs/proto3#enum) has to say about this:

*During deserialization, unrecognized enum values will be preserved in the message, though how this is represented when the message is deserialized is language-dependent. In languages that support open enum types with values outside the range of specified symbols, such as C++ and Go, the unknown enum value is simply stored as its underlying integer representation. In languages with closed enum types such as Java, a case in the enum is used to represent an unrecognized value, and the underlying integer can be accessed with special accessors. In either case, if the message is serialized the unrecognized value will still be serialized with the message.*

So I feel we should try harder to preserve unknown enum members.

Inside structs, these unknown enums are pretty distinguishable:
```julia
TestStruct{OneOf{TestEnum.T}}(OneOf{TestEnum.T}(:enum, TestEnum.B)) # we got 2, a known value

TestStruct{OneOf{TestEnum.T}}(OneOf{TestEnum.T}(:enum, TestEnum.<invalid #7>)) # we got 7, an unknown value
```