### PR TITLE
Message fields can have hex field numbers

### DIFF
--- a/src/parsing/proto_types.jl
+++ b/src/parsing/proto_types.jl
@@ -148,7 +148,7 @@ function parse_field(ps::ParserState, labelable::Bool=true)
     labelable && ps.is_proto3 && label == REQUIRED && (ps.errored = true) && error("Field `$(name)` has a `required` label which is not supported in proto3 syntax.")
     labelable && !ps.is_proto3 && label == DEFAULT && (ps.errored = true) && error("Field `$(name)` is missing a label (`required`, `optional` or `repeated`), this is not supported in proto2 syntax.")
     expectnext(ps, Tokens.EQ)
-    number = parse(Int, val(expectnext(ps, Tokens.DEC_INT_LIT)))
+    number = parse(Int, val(expectnext(ps, kind -> (kind == Tokens.DEC_INT_LIT || kind == Tokens.HEX_INT_LIT))))
     if !(1 <= number <= MAX_FIELD_NUMBER) || (19000 <= number <= 19999)
         ps.errored = true
         error("Invalid field number $number for field $name")

--- a/test/test_parser.jl
+++ b/test/test_parser.jl
@@ -62,6 +62,26 @@ end
         @test haskey(p.definitions, "A")
         @test p.definitions["A"] isa Parsers.MessageType
     end
+    
+    @testset "Single message proto file with single decimal-numbered field" begin
+        s, p, ctx = translate_simple_proto("message A { required uint32 b = 1234; }")
+
+        @test haskey(p.definitions, "A")
+        @test p.definitions["A"] isa Parsers.MessageType
+        @test p.definitions["A"].fields[1].name == "b"
+        @test p.definitions["A"].fields[1].number == 1234
+        @test p.definitions["A"].fields[1].type isa Parsers.UInt32Type
+    end
+
+    @testset "Single message proto file with single hex-numbered field" begin
+        s, p, ctx = translate_simple_proto("message A { required uint32 b = 0x4321; }")
+
+        @test haskey(p.definitions, "A")
+        @test p.definitions["A"] isa Parsers.MessageType
+        @test p.definitions["A"].fields[1].name == "b"
+        @test p.definitions["A"].fields[1].number == 0x4321
+        @test p.definitions["A"].fields[1].type isa Parsers.UInt32Type
+    end
 
     @testset "Single enum proto file" begin
         s, p, ctx = translate_simple_proto("enum A { a = 0; }")


### PR DESCRIPTION
This change allows fields in messages to have hex field numbers. Previously a message of the following form would have raised an error:

```proto2
message A {
    required uint32 b = 0x1234;
}
```

Added unit tests to test parsing of both decimal and hex field numbers. 

Question for maintainer: Are there other places where I can propagate this in a followup?