### PR TITLE
Allow trailing semicolon after `oneof` fields

### DIFF
--- a/src/parsing/proto_types.jl
+++ b/src/parsing/proto_types.jl
@@ -262,6 +262,7 @@ function parse_oneof_type(ps::ParserState, definitions, name_prefix="")
             push!(fields, parse_field(ps, false))
         end
     end
+    accept(ps, Tokens.SEMICOLON)
     return OneOfType(name, fields, options)
 end
 

--- a/test/test_parser.jl
+++ b/test/test_parser.jl
@@ -62,7 +62,7 @@ end
         @test haskey(p.definitions, "A")
         @test p.definitions["A"] isa Parsers.MessageType
     end
-    
+
     @testset "Single message proto file with single decimal-numbered field" begin
         s, p, ctx = translate_simple_proto("message A { required uint32 b = 1234; }")
 
@@ -93,7 +93,7 @@ end
     end
 
     @testset "Trailing semicolon is fine" begin
-        s, p, ctx = translate_simple_proto("message A {}; enum B { b = 0; };")
+        s, p, ctx = translate_simple_proto("message A { oneof oneof_field { uint32 u = 1; };}; enum B { b = 0; };")
 
         @test haskey(p.definitions, "A")
         @test p.definitions["A"] isa Parsers.MessageType


### PR DESCRIPTION
Fixes https://github.com/JuliaIO/ProtoBuf.jl/issues/211#issuecomment-1241219281