### PR TITLE
a few small fixes for codegen

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["protobuf", "protoc"]
 license = "MIT"
 desc = "Julia protobuf implementation"
 authors = ["Tomáš Drvoštěp <tomas.drvostep@gmail.com>"]
-version = "1.0.7"
+version = "1.0.8"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"

--- a/src/codegen/names.jl
+++ b/src/codegen/names.jl
@@ -4,7 +4,9 @@ const JULIA_RESERVED_KEYWORDS = Set{String}([
     "ccall", "finally", "typealias", "break", "continue", "type",
     "global", "module", "using", "import", "export", "const", "let",
     "bitstype", "do", "baremodule", "importall", "immutable",
-    "Type", "Enum", "Any", "DataType", "Base", "Set", "Method"
+    "Type", "Enum", "Any", "DataType", "Base", "Set", "Method",
+    "Array", "Vector", "Dict", "Union",
+    "OneOf",
 ])
 
 _get_name(t::AbstractProtoType) = t.name

--- a/src/codegen/toplevel_definitions.jl
+++ b/src/codegen/toplevel_definitions.jl
@@ -87,7 +87,8 @@ function generate_struct(io, t::MessageType, ctx::Context)
     params_string = get_type_param_string(type_params)
 
     print(io, "struct ", struct_name, length(t.fields) > 0 ? params_string : ' ', _maybe_subtype(abstract_base_name, ctx.options))
-    length(t.fields) > 0 && println(io)
+    # new line if there are fields, otherwise ensure that we have space before `end`
+    length(t.fields) > 0 ? println(io) : print(io, ' ')
     for field in t.fields
         generate_struct_field(io, field, ctx, type_params)
     end
@@ -175,7 +176,7 @@ function translate(io, rp::ResolvedProtoFile, file_map::Dict{String,ResolvedProt
     println(io, "import ProtoBuf as PB")
     options.common_abstract_type && println(io, "using ProtoBuf: AbstractProtoBufMessage")
     println(io, "using ProtoBuf: OneOf")
-    println(io, "using EnumX: @enumx")
+    println(io, "using ProtoBuf.EnumX: @enumx")
     if (is_namespaced(p) || options.always_use_modules) && !isempty(p.definitions)
         len = 93
         for name in Iterators.map(_safename, p.sorted_definitions)

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -312,6 +312,13 @@ end
         """
     end
 
+    @testset "Empty struct with common abstract type" begin
+        s, p, ctx = translate_simple_proto("message A { }", Options(always_use_modules=false, common_abstract_type=true))
+        @test generate_struct_str(p.definitions["A"], ctx) == """
+        struct A  <: AbstractProtoBufMessage end
+        """
+    end
+
     @testset "OneOf field codegen" begin
         s, p, ctx = translate_simple_proto("message A { oneof a { int32 b = 1; } }", Options(parametrize_oneofs=true))
         @test occursin("""

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -67,14 +67,14 @@ end
         @test s == """
         import ProtoBuf as PB
         using ProtoBuf: OneOf
-        using EnumX: @enumx"""
+        using ProtoBuf.EnumX: @enumx"""
 
         s, p, ctx = translate_simple_proto("", Options(always_use_modules=true))
         @test s == """
         module main_pb
         import ProtoBuf as PB
         using ProtoBuf: OneOf
-        using EnumX: @enumx
+        using ProtoBuf.EnumX: @enumx
         end # module"""
     end
 
@@ -84,7 +84,7 @@ end
         import ProtoBuf as PB
         using ProtoBuf: AbstractProtoBufMessage
         using ProtoBuf: OneOf
-        using EnumX: @enumx"""
+        using ProtoBuf.EnumX: @enumx"""
     end
 
     @testset "Minimal proto file with file imports" begin
@@ -93,7 +93,7 @@ end
         include("a_pb.jl")
         import ProtoBuf as PB
         using ProtoBuf: OneOf
-        using EnumX: @enumx"""
+        using ProtoBuf.EnumX: @enumx"""
 
         s, p, ctx = translate_simple_proto("import \"path/to/a\";", Dict("path/to/a" => ""), Options(always_use_modules=true))
         @test s == """
@@ -102,7 +102,7 @@ end
         import a_pb
         import ProtoBuf as PB
         using ProtoBuf: OneOf
-        using EnumX: @enumx
+        using ProtoBuf.EnumX: @enumx
         end # module"""
     end
 
@@ -113,7 +113,7 @@ end
         import .p
         import ProtoBuf as PB
         using ProtoBuf: OneOf
-        using EnumX: @enumx"""
+        using ProtoBuf.EnumX: @enumx"""
 
         s, p, ctx = translate_simple_proto("import \"path/to/a\";", Dict("path/to/a" => "package p;"), Options(always_use_modules=true))
         @test s == """
@@ -122,7 +122,7 @@ end
         import .p
         import ProtoBuf as PB
         using ProtoBuf: OneOf
-        using EnumX: @enumx
+        using ProtoBuf.EnumX: @enumx
         end # module"""
     end
 


### PR DESCRIPTION
This PR includes a few small fixes;
- I have added the reserved names `Array`, `Vector`, `Dict`, `Union` and `OneOf`.  These are names which, if used, would break the generated code because their `Base` names are used without any accommodation to qualify the names in those cases.  Ideally I'd like to add a whole lot more (every exported type from `Base`) as they can lead to nasty surprises even if they don't technically break the generated code, but technically adding any other reserved words would be breaking, whereas this PR is not.
- I fixed an edge case in which a space would be omitted when generating code for a 0-field `struct` which inherits from `AbstractProtoBufMessage`.  This would lead to broken code such as `struct A <: AbstractProtoBufMessageend`.  I have added a unit test for this case.
- `using EnumX` in code generation is now `using ProtoBuf.EnumX` which uses the `EnumX` belonging to `ProtoBuf` obviating the need for packages using protobuf to include `EnumX` in their environment.  Using indirect dependencies is a discouraged practice, however I think it makes sense in this case since the generated code is a bit like internal module code in that it may depend on internal details of the module.