### PR TITLE
Add type assertions when encoding OneOf members

### DIFF
--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -65,13 +65,13 @@ function print_field_encode_expr(io, f::GroupType, ctx::Context)
     println(io, "    !isnothing(x.$(jl_fieldname(f))) && ", field_encode_expr(f, ctx))
 end
 
-function print_field_encode_expr(io, fs::OneOfType, ::Context)
+function print_field_encode_expr(io, fs::OneOfType, ctx::Context)
     println(io, "    if isnothing(x.$(safename(fs)));")
     for f in fs.fields
         V = _decoding_val_type(f.type)
         V = isempty(V) ? "" : ", Val{$V}"
         println(io, "    elseif ", "x.$(safename(fs)).name === :", jl_fieldname(f))
-        println(io, "    " ^ 2, "PB.encode(e, $(string(f.number)), x.$(safename(fs))[]$V)")
+        println(io, "    " ^ 2, "PB.encode(e, $(string(f.number)), x.$(safename(fs))[]::$(jl_typename(f, ctx))$V)")
     end
     println(io, "    end")
 end
@@ -95,13 +95,13 @@ function print_field_encoded_size_expr(io, f::GroupType, ::Context)
     println(io, "    !isnothing(x.$(jl_fieldname(f))) && (encoded_size += ", field_encoded_size_expr(f), ')')
 end
 
-function print_field_encoded_size_expr(io, fs::OneOfType, ::Context)
+function print_field_encoded_size_expr(io, fs::OneOfType, ctx::Context)
     println(io, "    if isnothing(x.$(safename(fs)));")
     for f in fs.fields
         V = _decoding_val_type(f.type)
         V = isempty(V) ? "" : ", Val{$V}"
         println(io, "    elseif ", "x.$(safename(fs)).name === :", jl_fieldname(f))
-        println(io, "    " ^ 2, "encoded_size += PB._encoded_size(x.$(safename(fs))[], $(string(f.number))$V)")
+        println(io, "    " ^ 2, "encoded_size += PB._encoded_size(x.$(safename(fs))[]::$(jl_typename(f, ctx)), $(string(f.number))$V)")
     end
     println(io, "    end")
 end


### PR DESCRIPTION
This changes codegen for `encode` and `_encode_size` methods for OneOf types. This should help type inference, definitely in the case when we don't parameterize the parent struct. E.g. this changes code generated in tests for "complex_message_pb.jl" from:
```julia
...
 if isnothing(x.oneof_field);
    elseif x.oneof_field.name === :oneof_bytes_field
        PB.encode(e, 17, x.oneof_field[])
    elseif x.oneof_field.name === :oneof_string_field
        PB.encode(e, 18, x.oneof_field[])
    elseif x.oneof_field.name === :oneof_uint32_field
        PB.encode(e, 19, x.oneof_field[])
    elseif x.oneof_field.name === :oneof_uint64_field
        PB.encode(e, 20, x.oneof_field[])
    elseif x.oneof_field.name === :oneof_int32_field
        PB.encode(e, 21, x.oneof_field[])
...
```
to
```julia
...
 if isnothing(x.oneof_field);
    elseif x.oneof_field.name === :oneof_bytes_field
        PB.encode(e, 17, x.oneof_field[]::Vector{UInt8})
    elseif x.oneof_field.name === :oneof_string_field
        PB.encode(e, 18, x.oneof_field[]::String)
    elseif x.oneof_field.name === :oneof_uint32_field
        PB.encode(e, 19, x.oneof_field[]::UInt32)
    elseif x.oneof_field.name === :oneof_uint64_field
        PB.encode(e, 20, x.oneof_field[]::UInt64)
    elseif x.oneof_field.name === :oneof_int32_field
        PB.encode(e, 21, x.oneof_field[]::Int32)
...
```