### PR TITLE
Allow unpacked repeated primitives

### DIFF
--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -30,15 +30,16 @@ function field_encode_expr(@nospecialize(f::FieldType), ctx::Context)
         !isempty(encoding_val_type) && (encoding_val_type = ", Val{$encoding_val_type}")
         # TODO: do we want to allow unpacked representation? Docs say that parsers must always handle both cases
         # and since packed is strictly more efficient, currently we don't allow that.
-        # is_packed = parse(Bool, get(f.options, "packed", "false"))
-        # if is_packed
+        is_packed = parse(Bool, get(f.options, "packed", "false"))
+        if is_packed
             return "PB.encode(e, $(string(f.number)), x.$(jl_fieldname(f))$(encoding_val_type))"
-        # else
-        #     return """
-        #     for el in x.$(jl_fieldname(f))
-        #                 PB.encode(e, $(string(f.number)), el$(encoding_val_type))
-        #             end"""
-        # end
+        else
+	        return """
+		        for el in x.$(jl_fieldname(f))
+			        PB.encode(e, $(string(f.number)), el$(encoding_val_type))
+		        end
+	        """
+        end
     else
         return _field_encode_expr(f, ctx)
     end


### PR DESCRIPTION
When supporting an existing protocol which uses unpacked representation for encoding and decoding we need unpacked representation support. If it is strictly encoding and decoding at the other end it is not important. But before decoding if hash is used to verify the object received in remote session then we would get into issues. The hash of the encoded representation will be different and will be rejected in our use case. For now I had to make a fork with these changes and continue using it. It would be ideal if changes are in the upstream. I was assuming you guys must have a reason and didn’t bother to raise an issue. I hope you are convinced about the use-case. If I am the protocol designer and implementer I would definitely avoid unpacked representation but to adhere to existing protocol it would make sense to support it. If it is very rare scenario and it complexifies the repo maintainance I understand.
