### PR TITLE
Remove invalid escape sequence

### DIFF
--- a/test/test_lexers.jl
+++ b/test/test_lexers.jl
@@ -66,7 +66,6 @@ end
         lexer_test("\"proto3\"", Tokens.STRING_LIT)
         lexer_test("'\uffff'", Tokens.STRING_LIT)
         lexer_test("'\xff'", Tokens.STRING_LIT)
-        lexer_test("'\777'", Tokens.STRING_LIT)
         lexer_test("'\U000fffff'", Tokens.STRING_LIT)
         lexer_test("'\U0010ffff'", Tokens.STRING_LIT)
     end

--- a/test/test_lexers.jl
+++ b/test/test_lexers.jl
@@ -64,10 +64,11 @@ end
         lexer_test("\"a\"", Tokens.STRING_LIT)
         lexer_test("'a'", Tokens.STRING_LIT)
         lexer_test("\"proto3\"", Tokens.STRING_LIT)
-        lexer_test("'\uffff'", Tokens.STRING_LIT)
-        lexer_test("'\xff'", Tokens.STRING_LIT)
-        lexer_test("'\U000fffff'", Tokens.STRING_LIT)
-        lexer_test("'\U0010ffff'", Tokens.STRING_LIT)
+        lexer_test(raw"'\uffff'", Tokens.STRING_LIT)
+        lexer_test(raw"'\xff'", Tokens.STRING_LIT)
+        lexer_test(raw"'\777'", Tokens.STRING_LIT)
+        lexer_test(raw"'\U000fffff'", Tokens.STRING_LIT)
+        lexer_test(raw"'\U0010ffff'", Tokens.STRING_LIT)
     end
 
     @testset "numeric literals" begin


### PR DESCRIPTION
Found as part of testing for JuliaLang/julia#46372 - JuliaSyntax.jl rejects `\777` as this is above the maximum octal value for a `UInt8`.

The reference parser incorrectly saturates such invalid char literals to `\xff` and you've already got a test for that.