### PR TITLE
compat updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,14 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
+Aqua = "0.8"
 BufferedStreams = "1.2"
+Dates = "1"
 EnumX = "1"
-TranscodingStreams = "0.9"
+JET = "0.8"
+TranscodingStreams = "0.9, 0.10"
+TOML = "1"
+Test = "1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
* Update compat for `TranscodingStreams` to include v0.10.
* Include compats for stdlibs `Dates`, `Test`, `TOML`.  Ref https://discourse.julialang.org/t/psa-compat-requirements-in-the-general-registry-are-changing/104958
* Include compats for `Aqua` and `JET`, to pass tests that use `Aqua` and `JET`.
