### PR TITLE
Bugfix/broken submodule topological sort

### DIFF
--- a/src/topological_sort.jl
+++ b/src/topological_sort.jl
@@ -48,7 +48,7 @@ function _topological_sort(definitions::Dict{K}, ignored_keys::Union{Nothing,Set
     empty!(cyclic_definitions)
     if !isempty(number_of_upstream_dependencies)
         @debug "The input is not a DAG."
-        for cyclic_definition in first.(collect(number_of_upstream_dependencies), by=last)
+        for cyclic_definition in first.(collect(number_of_upstream_dependencies))
             push!(cyclic_definitions, cyclic_definition)
         end
         append!(topologically_sorted, cyclic_definitions)

--- a/src/topological_sort.jl
+++ b/src/topological_sort.jl
@@ -48,7 +48,7 @@ function _topological_sort(definitions::Dict{K}, ignored_keys::Union{Nothing,Set
     empty!(cyclic_definitions)
     if !isempty(number_of_upstream_dependencies)
         @debug "The input is not a DAG."
-        for cyclic_definition in first.(sort!(collect(number_of_upstream_dependencies), by=last))
+        for cyclic_definition in first.(collect(number_of_upstream_dependencies), by=last)
             push!(cyclic_definitions, cyclic_definition)
         end
         append!(topologically_sorted, cyclic_definitions)

--- a/src/topological_sort.jl
+++ b/src/topological_sort.jl
@@ -15,7 +15,6 @@ function _topological_sort(definitions::Dict{K}, ignored_keys::Union{Nothing,Set
         empty!(upstreams)
         get_upstream_dependencies!(definition, upstreams)
         has_ignored_keys && setdiff!(upstreams, ignored_keys)
-        intersect!(upstreams,keys(definitions))
         if length(upstreams) == 0
             push!(queue, name)
         else
@@ -27,9 +26,6 @@ function _topological_sort(definitions::Dict{K}, ignored_keys::Union{Nothing,Set
             push!(get!(downstream_dependencies, u, K[]), name)
         end
     end
-
-
-
 
     while !isempty(queue)
         u = popfirst!(queue)

--- a/src/topological_sort.jl
+++ b/src/topological_sort.jl
@@ -15,6 +15,7 @@ function _topological_sort(definitions::Dict{K}, ignored_keys::Union{Nothing,Set
         empty!(upstreams)
         get_upstream_dependencies!(definition, upstreams)
         has_ignored_keys && setdiff!(upstreams, ignored_keys)
+        intersect!(upstreams,keys(definitions))
         if length(upstreams) == 0
             push!(queue, name)
         else
@@ -26,6 +27,9 @@ function _topological_sort(definitions::Dict{K}, ignored_keys::Union{Nothing,Set
             push!(get!(downstream_dependencies, u, K[]), name)
         end
     end
+
+
+
 
     while !isempty(queue)
         u = popfirst!(queue)

--- a/test/test_protojl.jl
+++ b/test/test_protojl.jl
@@ -77,6 +77,26 @@ mktempdir() do tmpdir
                         @test include(joinpath(tmpdir, "protobuf_unittest/protobuf_unittest.jl")) isa Module
                     end
                 end
+
+                @testset "google/protobuf/complex_dependencies/*" begin
+                    @testset "translate source" begin
+                        test_dir = "test_protos/google/protobuf/complex_dependencies"
+                        @test isnothing(protojl(
+                            ["da.proto","g.proto","c.proto","d.proto","e.proto"],
+                            joinpath(@__DIR__,test_dir),
+                            tmpdir;
+                            options...
+                         ))
+                    end
+                    @testset "include generated" begin
+                        @test include(joinpath(tmpdir, "test/test.jl")) isa Module
+                        @test test.da.A isa Type
+                        @test test.c.C isa Type
+                        @test test.d.D isa Type
+                        @test test.test2.e.Ef isa Type
+                        @test test.test2.g.G isa Type
+                    end
+                end
             end
         end
     end

--- a/test/test_protos/google/protobuf/complex_dependencies/c.proto
+++ b/test/test_protos/google/protobuf/complex_dependencies/c.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package test.c;
+
+
+import "e.proto";
+import "g.proto";
+import "d.proto";
+
+message C{
+  d.D d = 1;
+  .test2.e.Ef e = 2;
+  .test2.g.G g = 4;
+}
+
+

--- a/test/test_protos/google/protobuf/complex_dependencies/d.proto
+++ b/test/test_protos/google/protobuf/complex_dependencies/d.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package test.d;
+
+
+message D{
+  float d = 2;
+}
+

--- a/test/test_protos/google/protobuf/complex_dependencies/da.proto
+++ b/test/test_protos/google/protobuf/complex_dependencies/da.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package test.da;
+
+import "c.proto";
+
+message A{
+  c.C c = 2;
+  float a = 3;
+}

--- a/test/test_protos/google/protobuf/complex_dependencies/e.proto
+++ b/test/test_protos/google/protobuf/complex_dependencies/e.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test2.e;
+
+message Ef{
+  float e = 1;
+}

--- a/test/test_protos/google/protobuf/complex_dependencies/g.proto
+++ b/test/test_protos/google/protobuf/complex_dependencies/g.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package test2.g;
+
+message G{
+  float g = 1;
+}
+


### PR DESCRIPTION
This is a bugfix for a subtle issue in the topological sorting of nested submodules.
The issue occurs when

1. Submodules are nested at least 2 deep
2. A module imports a another module, traversing up 2 levels (such as mod1.a imports mod2.b)
3. One of the modules upstream of the module that does this is named such that its name is lexographically less than the aforementioned module

This issue occurs due to the fact that when sorting submodules, the external modules are not included in the sort however they are still returned from `get_upstream_dependencies!`  This breaks the algorithms and causes nodes with these dependencies to not be processed and instead be falsely identified as cyclical dependencies.

The result of this is that the generated files have the wrong import order, which results in undefined references.

I have added and example of this occurring to the tests.