### PR TITLE
Add julia_package option support

### DIFF
--- a/src/parsing/Parsers.jl
+++ b/src/parsing/Parsers.jl
@@ -205,6 +205,7 @@ function parse_proto_file(ps::ParserState)
             definitions[type.name] = type
         end
     end
+    package_identifier = get(options, "julia_package", package_identifier)
     package_parts = split(package_identifier, '.', keepempty=false)
     preamble = ProtoFilePreamble(
         ps.is_proto3,

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -126,6 +126,12 @@ end
         end # module"""
     end
 
+    @testset "Minimal proto file with julia_package option" begin
+        s, p, ctx = translate_simple_proto("""syntax = "proto3"; option julia_package = "Foo.Bar.Baz";""", Options(always_use_modules=false))
+        @test "Foo.Bar.Baz" == p.preamble.options["julia_package"]
+        @test ["Foo", "Bar", "Baz"] == namespace(p)
+    end
+
     @testset "`force_required` option makes optional fields required" begin
         s, p, ctx = translate_simple_proto("message A {} message B { optional A a = 1; }", Options(force_required=Dict("main" => Set(["B.a"]))))
         ctx._toplevel_name[] = "B"

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -130,6 +130,10 @@ end
         s, p, ctx = translate_simple_proto("""syntax = "proto3"; option julia_package = "Foo.Bar.Baz";""", Options(always_use_modules=false))
         @test "Foo.Bar.Baz" == p.preamble.options["julia_package"]
         @test ["Foo", "Bar", "Baz"] == namespace(p)
+
+        @test_throws ErrorException begin
+            translate_simple_proto("""syntax = "proto3"; option julia_package = "Foo/Bar/Baz";""", Options(always_use_modules=false))
+        end
     end
 
     @testset "`force_required` option makes optional fields required" begin

--- a/test/test_protojl.jl
+++ b/test/test_protojl.jl
@@ -316,3 +316,28 @@ using ProtoBuf
     @test pairs_message.map_field == decoded_pairs.map_field
 end
 end
+
+module TestJuliaPackage
+using Test
+using ProtoBuf
+
+@testset "Use julia_package option" begin
+    mktempdir() do tmpdir
+        @testset "translate source" begin
+            @test isnothing(protojl(
+                "test_julia_package.proto",
+                joinpath(@__DIR__, "test_protos/"),
+                tmpdir;
+                always_use_modules=false,
+                parametrize_oneofs=false
+            ))
+        end
+        @testset "include generated" begin
+            @test include(joinpath(tmpdir, "Foo/Foo.jl")) isa Module
+            @test Foo.Bar.Baz.Message isa Type
+            @test :message == fieldnames(Foo.Bar.Baz.Message)[1]
+            @test String == fieldtypes(Foo.Bar.Baz.Message)[1]
+        end
+    end
+end
+end

--- a/test/test_protos/test_julia_package.proto
+++ b/test/test_protos/test_julia_package.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option julia_package = "Foo.Bar.Baz";
+
+message Message {
+    string message = 1;
+};


### PR DESCRIPTION
I'd like to add `julia_package` option to overwrite the package identifier specified in `package` statement.