### PR TITLE
Jet Version Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["protobuf", "protoc"]
 license = "MIT"
 desc = "Julia protobuf implementation"
 authors = ["Tomáš Drvoštěp <tomas.drvostep@gmail.com>"]
-version = "1.0.16"
+version = "1.0.17"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
@@ -17,10 +17,10 @@ Aqua = "0.8"
 BufferedStreams = "1.2"
 Dates = "1"
 EnumX = "1"
-JET = "0.4, 0.5, 0.6, 0.7, 0.8"
+JET = "0.9.12"
 TOML = "1"
 Test = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/codegen/toplevel_definitions.jl
+++ b/src/codegen/toplevel_definitions.jl
@@ -85,8 +85,9 @@ function generate_struct(io, t::MessageType, ctx::Context)
     abstract_base_name = pop!(ctx._curr_cyclic_defs, t.name, "")
     type_params = get_type_params(t, ctx)
     params_string = get_type_param_string(type_params)
+    struct_definition = ctx.options.with_mutable_structs ? "mutable struct " : "struct "
 
-    print(io, "struct ", struct_name, length(t.fields) > 0 ? params_string : ' ', _maybe_subtype(abstract_base_name, ctx.options))
+    print(io, struct_definition, struct_name, length(t.fields) > 0 ? params_string : ' ', _maybe_subtype(abstract_base_name, ctx.options))
     # new line if there are fields, otherwise ensure that we have space before `end`
     length(t.fields) > 0 ? println(io) : print(io, ' ')
     for field in t.fields

--- a/src/parsing/Parsers.jl
+++ b/src/parsing/Parsers.jl
@@ -202,7 +202,12 @@ function parse_proto_file(ps::ParserState)
             push!(extends, parse_extend_type(ps, definitions))
         else
             type = parse_type(ps, definitions)
-            definitions[type.name] = type
+            # Condition added to ensure that only types that can be values of the definitions
+            # can be set as values. There are some types that can be returned from parse_type
+            # that don't have the `name` field, like `ExtendType`, and this condition filters them out.
+            if isa(type, MessageType) || isa(type, EnumType) || isa(type, ServiceType)
+                definitions[type.name] = type
+            end
         end
     end
     package_parts = split(package_identifier, '.', keepempty=false)


### PR DESCRIPTION
Due to the error thrown by JET versions less than `0.9.12` that were previously used in this package, this PR seeks to update the JET version to `0.9.12`. The change also led to the update of the Julia compat version to 1.10.

Having updated JET, an error was detected on the Parsers.jl file where some types being passed to the definitions dictionary in the `parse_proto_file` function did not contain the `name` field. This PR restricts the types passed to those that have the `name` field; which happen to be the allowed set of types that can be value of the definitions dictionary.

These changes make the tests pass, at least locally.
