### PR TITLE
Fix a bug with sending -0.0 for floats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["protobuf", "protoc"]
 license = "MIT"
 desc = "Julia protobuf implementation"
 authors = ["Tomáš Drvoštěp <tomas.drvostep@gmail.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"

--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -6,6 +6,7 @@ function encode_condition(f::FieldType, ctx::Context)
     end
 end
 _encode_condition(@nospecialize(f::FieldType), ctx::Context) = "x.$(jl_fieldname(f)) != $(jl_init_value(f, ctx))"
+_encode_condition(f::FieldType{<:AbstractProtoFloatType}, ctx:: Context) = "!isequal(x.$(jl_fieldname(f)), $(jl_init_value(f, ctx)))"
 _encode_condition(f::FieldType{<:MapType}, ::Context) = "!isempty(x.$(jl_fieldname(f)))"
 function _encode_condition(f::FieldType{T}, ctx::Context) where {T<:Union{StringType,BytesType}}
     default = get(f.options, "default", nothing)

--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -6,7 +6,7 @@ function encode_condition(f::FieldType, ctx::Context)
     end
 end
 _encode_condition(@nospecialize(f::FieldType), ctx::Context) = "x.$(jl_fieldname(f)) != $(jl_init_value(f, ctx))"
-_encode_condition(f::FieldType{<:AbstractProtoFloatType}, ctx:: Context) = "!isequal(x.$(jl_fieldname(f)), $(jl_init_value(f, ctx)))"
+_encode_condition(f::FieldType{<:AbstractProtoFloatType}, ctx:: Context) = "x.$(jl_fieldname(f)) !== $(jl_init_value(f, ctx))"
 _encode_condition(f::FieldType{<:MapType}, ::Context) = "!isempty(x.$(jl_fieldname(f)))"
 function _encode_condition(f::FieldType{T}, ctx::Context) where {T<:Union{StringType,BytesType}}
     default = get(f.options, "default", nothing)

--- a/test/test_protojl.jl
+++ b/test/test_protojl.jl
@@ -246,6 +246,9 @@ end
 
         var"OmniMessage.Group"(Int32(42)),
         [var"OmniMessage.Repeated_group"(Int32(43))],
+
+        Float32(-0.0), # Checks that -0.0 is serialized and not confused with the 0.0 default value
+        Float64(-0.0),
     )
 
     @testset "IOBuffer" begin

--- a/test/test_protos/complex_message.proto
+++ b/test/test_protos/complex_message.proto
@@ -112,6 +112,9 @@ message OmniMessage {
     repeated group Repeated_group = 83 {
         optional int32 a = 1;
     }
+
+    optional float float_field_2 = 84;
+    optional double double_field_2 = 85;
 }
 
 message DuplicatedInnerMessage { optional uint32 x = 1; repeated uint32 y = 2; optional DuplicatedMessage r = 3; }


### PR DESCRIPTION
Currently, when we're encoding a value to send we check something like `x != zero(T)` to decide if we're going to send anything. This is fine for almost every type, but for floats in particular `==` and `isequal` are not the same. In particular, `0.0 == -0.0`, which means that `-0.0` has no message sent and roundtrips back to `0.0`, which is incorrect. This is called out directly in the proto spec https://protobuf.dev/programming-guides/proto3/, as "-0 is considered distinct and will be serialized."

The fix is for float types we should instead use `isequal`. 