### PR TITLE
Access `skip` from its owning module

### DIFF
--- a/src/codegen/decode_methods.jl
+++ b/src/codegen/decode_methods.jl
@@ -100,7 +100,7 @@ function generate_decode_method(io, t::MessageType, ctx::Context)
         field_decode_expr(io, field, i, ctx)
     end
     has_fields && println(io, "        else")
-    println(io, "    " ^ (3 - !has_fields), "PB.skip(d, wire_type)")
+    println(io, "    " ^ (3 - !has_fields), "Base.skip(d, wire_type)")
     has_fields && println(io, "        end")
     println(io, "    end")
     print(io, "    return ")


### PR DESCRIPTION
Noticed when running ExplicitImports.jl on a module with PB generated files. 
Got:
```jl
Module `Foo.Rel` has qualified accesses to names via modules other than their owner as determined via `Base.which`:
- `skip` has owner `Base` but it was accessed from `ProtoBuf` at `~/Foo/src/Rel/Rel_pb.jl:1019:16`
```