### PR TITLE
32bit support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - samysweb/fix-32bit
     tags: '*'
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - samysweb/fix-32bit
     tags: '*'
 jobs:
   test:
@@ -25,6 +26,7 @@ jobs:
           - macOS-14
         arch:
           - x64
+          - x86
           - aarch64
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           - macOS-14
         arch:
           - x64
-          - x86
+          - x86 # Test
           - aarch64
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
             arch: x64
           - os: macOS-14
             version: '1.6'
+          - os: macOS-14
+            arch: x86
+          - os: macOS-13
+            arch: x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/src/codec/Codecs.jl
+++ b/src/codec/Codecs.jl
@@ -15,7 +15,7 @@ ProtoDecoder(io::IO) = ProtoDecoder(io, eof)
 
 struct LengthDelimitedProtoDecoder{I<:IO} <: AbstractProtoDecoder
     io::I
-    endpos::Int
+    endpos::Int64
 end
 message_done(d::LengthDelimitedProtoDecoder) = d.endpos == position(d.io)
 

--- a/src/codec/decode.jl
+++ b/src/codec/decode.jl
@@ -189,7 +189,7 @@ end
 function decode(d::AbstractProtoDecoder, ::Type{Ref{T}}) where {T}
     bytelen = vbyte_decode(d.io, UInt32)
     endpos = bytelen + position(d.io)
-    endpos = convert(endpos, Int64)
+    endpos = convert(Int64, endpos)
     out = decode(LengthDelimitedProtoDecoder(d.io, endpos), T)
     @assert position(d.io) == endpos
     return out

--- a/src/codec/decode.jl
+++ b/src/codec/decode.jl
@@ -189,6 +189,7 @@ end
 function decode(d::AbstractProtoDecoder, ::Type{Ref{T}}) where {T}
     bytelen = vbyte_decode(d.io, UInt32)
     endpos = bytelen + position(d.io)
+    endpos = convert(endpos, Int64)
     out = decode(LengthDelimitedProtoDecoder(d.io, endpos), T)
     @assert position(d.io) == endpos
     return out

--- a/test/test_perf.jl
+++ b/test/test_perf.jl
@@ -26,10 +26,10 @@ vbyte_decode(io, UInt64)
 
 @test_noalloc vbyte_encode(io, typemax(UInt32))
 seekstart(io)
-@test @allocated(vbyte_decode(io, UInt32)) == 16
+@test @allocated(vbyte_decode(io, UInt32)) <= 16 # 32 Bit systems require fewer allocations
 @test_noalloc vbyte_encode(io, typemax(UInt64))
 seekstart(io)
-@test @allocated(vbyte_decode(io, UInt64)) == 16
+@test @allocated(vbyte_decode(io, UInt64)) <= 16 # 32 Bit systems require fewer allocations
 
 @enumx TestEnum DEFAULT=0 OTHER=1
 

--- a/test/test_protojl.jl
+++ b/test/test_protojl.jl
@@ -187,7 +187,7 @@ end
         typemax(UInt32),
         typemax(UInt64),
         EmptyMessage(),
-        NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, 1), nothing), OneOf(:y, 2), nothing),
+        NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, Int64(1)), nothing), OneOf(:y, Int64(2)), nothing),
         OneOf(:oneof_uint32_field, typemax(UInt32)),
 
         [UInt8[0xff]],
@@ -206,8 +206,8 @@ end
         [typemax(UInt64)],
         [EmptyMessage()],
         [
-            NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, 3), nothing), OneOf(:y, 4), nothing),
-            NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, 3), nothing), OneOf(:y, 4), CoRecursiveMessage(nothing)),
+            NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, Int64(3)), nothing), OneOf(:y, Int64(4)), nothing),
+            NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, Int64(3)), nothing), OneOf(:y, Int64(4)), CoRecursiveMessage(nothing)),
         ],
 
         Dict("K" => UInt8[0xff]),
@@ -226,8 +226,8 @@ end
         Dict("K" => typemax(UInt64)),
         Dict("K" => EmptyMessage()),
         Dict(
-            "K1" => NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, 5), nothing), OneOf(:y, 6), nothing),
-            "K2" => NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, 5), nothing), OneOf(:y, 6), CoRecursiveMessage(nothing)),
+            "K1" => NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, Int64(5)), nothing), OneOf(:y, Int64(6)), nothing),
+            "K2" => NonEmptyMessage(typemax(UInt32), NonEmptyMessage(typemax(UInt32), nothing, OneOf(:y, Int64(5)), nothing), OneOf(:y, Int64(6)), CoRecursiveMessage(nothing)),
 
         ),
 
@@ -302,9 +302,9 @@ using ProtoBuf
     end
 
     test_dictionary = Dict{String, Int64}(
-        "field1"=>1,
-        "field2"=>-5,
-        "field3"=>120,
+        "field1"=>Int64(1),
+        "field2"=>Int64(-5),
+        "field3"=>Int64(120),
     )
 
     dict_message = Map(test_dictionary)


### PR DESCRIPTION
This pull request intends to make ProtoBuf.jl and its CI compatible to 32-bit architectures (x86).

For CI I tried to run ProtoBuf.jl on a 32-bit system and noticed a bug due to the way `LengthDelimitedProtoDecoder` implements `endpos`:  
`Int` is platform-dependent in Julia, and hence this corresponds to `Int32` in 32-bit systems.
Conversely, IOBuffer (what my test uses) [uniformly returns `Int64` for position independently of the platform](https://github.com/JuliaLang/julia/blob/master/base/iostream.jl#L248).

This issue also becomes visible [when activating the CI of ProtoBuf.jl for x86](https://github.com/samysweb/ProtoBuf.jl/actions/runs/16294489858/job/46012345897) although for a different reason (UInt32 not converted into Int32).
I propose to uniformly use `Int64` as an endmarker and to perform explicit conversion (see suggested changes to `Codecs.jl` and `decode.jl`.
I've also updated the tests in `test_protojl.jl` to make the choice of Integer type explicit (which is lateron checked) and to account for the fewer allocations on x86 systems in `test_perf.jl`.

With these changes, the CI now runs flawlessly everywhere except for [x86 Julia nightly](https://github.com/samysweb/ProtoBuf.jl/actions/runs/16304258706/job/46046407265).
Where a Dict seems to be encoded in the opposite order for Julia Nightly on x86 (?).
Note that two tests fail and that expected/observed outputs are swapped between the two tests...
I am open to fixing this remaining bug, but would require your guidance on whether this is an implementation bug or a limitation of the current test?