### PR TITLE
Fix name clash falsely classifying `ReferencedType` as cyclic or self referential

### DIFF
--- a/src/codegen/CodeGenerators.jl
+++ b/src/codegen/CodeGenerators.jl
@@ -40,7 +40,7 @@ struct Context
     file_map::Dict{String,ResolvedProtoFile}
     _types_and_oneofs_requiring_type_params::Dict{String,Vector{Tuple{Bool,String}}}
     _remaining_cyclic_defs::Set{String}
-    _toplevel_raw_name::Ref{String}
+    _toplevel_raw_name::Ref{Tuple{String, Vector{String}}}
     transitive_imports::Set{String}
     options::Options
 end

--- a/src/codegen/defaults.jl
+++ b/src/codegen/defaults.jl
@@ -15,8 +15,8 @@ function jl_default_value(@nospecialize(field::FieldType), ctx::Context)
 end
 
 function _is_optional_referenced_message(field::Union{FieldType{ReferencedType},GroupType}, ctx::Context)
-    struct_name = ctx._toplevel_raw_name[]
-    (field.type.name == struct_name || field.type.name in ctx._remaining_cyclic_defs) && return true
+    struct_name, _ = ctx._toplevel_raw_name[]
+    (_is_self_referential_field(field.type, ctx) || field.type.name in ctx._remaining_cyclic_defs) && return true
     if field.label == Parsers.OPTIONAL || field.label == Parsers.DEFAULT
         return !_should_force_required(string(struct_name, ".", jl_fieldname(field)), ctx)
     end

--- a/src/parsing/utils.jl
+++ b/src/parsing/utils.jl
@@ -121,7 +121,10 @@ get_type_name(t::MapType)          = get_type_name(t.valuetype) # messages and e
 function _is_self_reference!(t::MessageType, field_type_name::Union{Nothing,String})
     isnothing(field_type_name) && return true  # don't push as dependency
     if t.name == field_type_name
-        t.is_self_referential[] = true
+        # Note: When this is called during _topological_sort and the field is a reference
+        # it should have a name of the form `t.name == "<package>.<fieldname>"`, making the above
+        # comparison in the edge case when referring to B.C in A, even if A.C exists.  
+        t.has_self_reference[] = true
         return true  # don't push as dependency
     end
     return false # push as dependency

--- a/test/test_parser.jl
+++ b/test/test_parser.jl
@@ -22,7 +22,7 @@ function translate_simple_proto(str::String, options=Options())
         p, r.import_path, d,
         types_needing_params(@view(p.sorted_definitions[end-ncyclic+1:end]), p, options),
         copy(p.cyclic_definitions),
-        Ref(get(p.sorted_definitions, length(p.sorted_definitions), "")),
+        Ref((get(p.sorted_definitions, length(p.sorted_definitions), ""), namespace(p))),
         r.transitive_imports,
         options
     )
@@ -52,7 +52,7 @@ function translate_simple_proto(str::String, deps::Dict{String,String}, options=
         p, r.import_path, d,
         types_needing_params(@view(p.sorted_definitions[end-ncyclic+1:end]), p, options),
         copy(p.cyclic_definitions),
-        Ref(get(p.sorted_definitions, length(p.sorted_definitions), "")),
+        Ref((get(p.sorted_definitions, length(p.sorted_definitions), ""), namespace(p))),
         r.transitive_imports,
         options
     )
@@ -240,7 +240,7 @@ end
         @test p.definitions["A"].fields[1].type.name == "B"
         # we were able to infer the type of the dependency by finding it among imported modules
         @test p.definitions["A"].fields[1].type.reference_type == Parsers.MESSAGE
-        @test p.definitions["A"].fields[1].type.package_namespace === "P"
+        @test p.definitions["A"].fields[1].type.package_namespace_str === "P"
     end
 
     @testset "Single message with package-imported namespaced field type" begin
@@ -258,7 +258,7 @@ end
         @test p.definitions["A"].fields[1].type isa Parsers.ReferencedType
         @test p.definitions["A"].fields[1].type.name == "B"
         @test p.definitions["A"].fields[1].type.reference_type == Parsers.MESSAGE
-        @test p.definitions["A"].fields[1].type.package_namespace == "P"
+        @test p.definitions["A"].fields[1].type.package_namespace_str == "P"
         @test p.definitions["A"].fields[1].type.package_import_path == "path/to/a"
     end
 
@@ -279,7 +279,7 @@ end
         @test p.definitions["A"].fields[1].type isa Parsers.ReferencedType
         @test p.definitions["A"].fields[1].type.name == "B"
         @test p.definitions["A"].fields[1].type.reference_type == Parsers.MESSAGE
-        @test p.definitions["A"].fields[1].type.package_namespace == "P"
+        @test p.definitions["A"].fields[1].type.package_namespace_str == "P"
         @test p.definitions["A"].fields[1].type.package_import_path == "path/to/a"
 
         @test p.definitions["A"].fields[2].name == "b_local"
@@ -287,7 +287,7 @@ end
         @test p.definitions["A"].fields[2].type isa Parsers.ReferencedType
         @test p.definitions["A"].fields[2].type.name == "B"
         @test p.definitions["A"].fields[2].type.reference_type == Parsers.MESSAGE
-        @test p.definitions["A"].fields[2].type.package_namespace === nothing
+        @test p.definitions["A"].fields[2].type.package_namespace_str === nothing
         @test p.definitions["A"].fields[2].type.package_import_path === nothing
     end
 


### PR DESCRIPTION
Closes https://github.com/JuliaIO/ProtoBuf.jl/issues/289

# Description

After `_postprocess_reference!`, names such as `A.B` are changed into simply `B`. Subsequently, codegen decides whether a field of a message matches the message name itself, without taking the namespace into account. See e.g. 
https://github.com/JuliaIO/ProtoBuf.jl/blob/5fed2e71f465ebcf7ae5eaaa116cca7f2ca01c04/src/parsing/utils.jl#L49-L52

https://github.com/JuliaIO/ProtoBuf.jl/blob/5fed2e71f465ebcf7ae5eaaa116cca7f2ca01c04/src/codegen/utils.jl#L77-L79

This discards information necessary to determine whether a reference really is self-referring or cyclic, because a message name may exist in multiple namespaces. 

For example, a struct such as 
```protobuf
package A;
message X {
    optional X x1 = 1;
    optional B.X y2 = 2;
}

...

package A.B;
message X{};
```
Will result in 
```julia
# in A
struct X
    x1::Union{Nothing,X}
    y2::Union{Nothing,X}
end
```
This request fixes so that we instead get 
```julia
# in A
struct X
    x1::Union{Nothing,X}
    y2::Union{Nothing,A.B.X}
end
```
The same issue also exists for cyclic references. Previously, all references with the same name would get parametrized. With these changes, references to the same name in another namespace are not parametrized. 

# Changes 
The overall logic conveyed here is that a field being self-referential is not only determined by the name of the field, but also by the namespace. Checking for self-references must be done per-field, taking namespace into consideration. The same problem applies to cyclic references. 

* `ctx._toplevel_raw_name[]` is now a tuple of the form `("name", ["pkg_lvl1" "pkg_lvl2"])`, acting as a non-ambiguous definition of a reference. 
* The field `Message.is_self_reference` is renamed to `has_self_reference`, clarifying that self-referentiality is the property of a field in the context of a message, not of a message itself. A message may have many fields, but not all are self references. 
* ReferencedType: 
  * The field `ReferencedType.namespace` is added to allow comparison to `ctx._toplevel_raw_name[]`. 
  * The field `ReferencedType.package_namespace` is renamed to `package_namespace_str` to clarify that this is formatted as a value for printing, not for comparisons. It may have parametrizations etc. making it unsuitable for processing purposes. 
* The function `_is_self_referential_field` now performs all evaluations proposed by the name. The behavior in practice is only changed for `ReferencedType` in the case when only `A` and `B.A` exist. 
* Similarly, the function `appears_in_cycle` is added. 
* See test for further description of the expected behavior. 