### PR TITLE
Introduce `TaggedOneOf`

### DIFF
--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -49,7 +49,7 @@ include("codec/Codecs.jl")
 import .Lexers
 import .Parsers
 import .CodeGenerators
-import .CodeGenerators: protojl
+import .CodeGenerators: TaggedOneOf, protojl, unsafe_getproperty, field_to_tag, active_name, active_value, throw_bad_tag, throw_not_set, tag
 import .Codecs
 import .Codecs: decode, decode!, encode, AbstractProtoDecoder, AbstractProtoEncoder, ProtoDecoder, BufferedVector, ProtoEncoder, message_done, decode_tag, skip, _encoded_size
 

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -28,7 +28,8 @@ function __init__()
     return nothing
 end
 
-struct OneOf{T}
+abstract type AbstractOneOf end
+struct OneOf{T} <: AbstractOneOf
     name::Symbol
     value::T
 end

--- a/src/ProtoBuf.jl
+++ b/src/ProtoBuf.jl
@@ -28,8 +28,7 @@ function __init__()
     return nothing
 end
 
-abstract type AbstractOneOf end
-struct OneOf{T} <: AbstractOneOf
+struct OneOf{T}
     name::Symbol
     value::T
 end

--- a/src/codegen/CodeGenerators.jl
+++ b/src/codegen/CodeGenerators.jl
@@ -10,6 +10,7 @@ import ..Parsers: GroupType, OneOfType, MapType, FieldType
 import ..Parsers: MessageType, EnumType, ServiceType, RPCType, ReferencedType
 import ..Parsers: AbstractProtoType, AbstractProtoNumericType, AbstractProtoFixedType
 import ..Parsers: AbstractProtoFloatType, AbstractProtoFieldType
+import ..Parsers: TypeInfo
 import ..ProtoBuf: VENDORED_WELLKNOWN_TYPES_PARENT_PATH, PACKAGE_VERSION
 import ..ProtoBuf: _topological_sort, get_upstream_dependencies!
 
@@ -52,6 +53,8 @@ include("defaults.jl")
 include("decode_methods.jl")
 include("encode_methods.jl")
 include("metadata_methods.jl")
+include("type_info.jl")
+include("tagged_oneofs.jl")
 include("toplevel_definitions.jl")
 include("utils.jl")
 
@@ -162,7 +165,7 @@ function _protojl(
     # Ensure that all paths are use slash as a separator,
     # so that equality checks between paths behave as expected,
     # which can be problematic on windows where both / and \ argument
-    # valid separators. This also reduces consecutive separators into one. 
+    # valid separators. This also reduces consecutive separators into one.
     map!(posixpath, absolute_paths, absolute_paths)
     map!(posixpath, relative_paths, relative_paths)
     map!(posixpath, search_directories, search_directories)

--- a/src/codegen/CodeGenerators.jl
+++ b/src/codegen/CodeGenerators.jl
@@ -7,7 +7,7 @@ import ..Parsers: Int64Type, UInt32Type, UInt64Type, SInt32Type, SInt64Type
 import ..Parsers: Fixed32Type, Fixed64Type, SFixed32Type, SFixed64Type, BoolType
 import ..Parsers: StringType, BytesType
 import ..Parsers: GroupType, OneOfType, MapType, FieldType
-import ..Parsers: MessageType, EnumType, ServiceType, RPCType, ReferencedType
+import ..Parsers: MessageType, EnumType, ServiceType, RPCType, ReferencedType, TaggedOneOfType
 import ..Parsers: AbstractProtoType, AbstractProtoNumericType, AbstractProtoFixedType
 import ..Parsers: AbstractProtoFloatType, AbstractProtoFieldType
 import ..Parsers: TypeInfo

--- a/src/codegen/CodeGenerators.jl
+++ b/src/codegen/CodeGenerators.jl
@@ -49,12 +49,12 @@ end
 include("modules.jl")
 include("names.jl")
 include("types.jl")
+include("tagged_oneofs.jl")
 include("defaults.jl")
 include("decode_methods.jl")
 include("encode_methods.jl")
 include("metadata_methods.jl")
 include("type_info.jl")
-include("tagged_oneofs.jl")
 include("toplevel_definitions.jl")
 include("utils.jl")
 

--- a/src/codegen/CodeGenerators.jl
+++ b/src/codegen/CodeGenerators.jl
@@ -31,6 +31,7 @@ Base.@kwdef struct Options
     add_kwarg_constructors::Bool = false
     parametrize_oneofs::Bool = false
     common_abstract_type::Bool = false
+    tagged_oneofs::Bool = false
 end
 
 struct Context
@@ -133,8 +134,10 @@ function protojl(
     add_kwarg_constructors::Bool=false,
     parametrize_oneofs::Bool=false,
     common_abstract_type::Bool = false,
+    tagged_oneofs::Bool = false,
 )
-    options = Options(include_vendored_wellknown_types, always_use_modules, force_required, add_kwarg_constructors, parametrize_oneofs, common_abstract_type)
+    xor(tagged_oneofs, parametrize_oneofs) || throw(ArgumentError("..."))
+    options = Options(include_vendored_wellknown_types, always_use_modules, force_required, add_kwarg_constructors, parametrize_oneofs, common_abstract_type, tagged_oneofs)
     return _protojl(relative_paths, search_directories, output_directory, options)
 end
 

--- a/src/codegen/decode_methods.jl
+++ b/src/codegen/decode_methods.jl
@@ -78,7 +78,7 @@ end
 function field_decode_expr(io, field::OneOfType, i, ctx::Context)
     field_name = jl_fieldname(field)
     if ctx.options.tagged_oneofs
-        typename = string("var\"", ctx._toplevel_raw_name[], ".", replace(titlecase(field.name), "_"=>""), "\"")
+        typename = jl_tagged_type_name(field, ctx)
         for (j, case) in enumerate(field.fields)
             j += i
             print(io, "    " ^ 2, j == 2 ? "if     " : "elseif ", "field_number == ", string(case.number), "; ")

--- a/src/codegen/decode_methods.jl
+++ b/src/codegen/decode_methods.jl
@@ -45,8 +45,7 @@ function field_decode_expr(io, f::FieldType, i, ctx::Context)
     else
         decode_expr = jl_type_decode_expr(f, ctx)
     end
-    println(io, "    " ^ 2, i == 1 ? "if " : "elseif ", "field_number == ", string(f.number))
-    println(io, "    " ^ 3, decode_expr)
+    println(io, "    " ^ 2, i == 1 ? "if     " : "elseif ", "field_number == ", string(f.number), "; ", decode_expr)
     return nothing
 end
 
@@ -62,12 +61,35 @@ function jl_type_oneof_decode_expr(f::FieldType{ReferencedType}, ctx::Context)
       _is_message(f.type, ctx) && return "OneOf(:$(jl_fieldname(f)), PB.decode(d, Ref{$(jl_typename(f.type, ctx))}))"
       return "OneOf(:$(jl_fieldname(f)), PB.decode(d, $(jl_typename(f.type, ctx))))"
 end
+
+jl_type_tagged_oneof_decode_expr(f::FieldType, typename, ctx::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, $(jl_typename(f.type, ctx))))"
+jl_type_tagged_oneof_decode_expr(f::GroupType, typename, ctx::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Ref{$(jl_typename(f.type, ctx))}, Val{:group}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SFixed32Type}, typename, ::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int32, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SFixed64Type}, typename, ::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int64, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{Fixed32Type}, typename, ::Context)  = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, UInt32, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{Fixed64Type}, typename, ::Context)  = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, UInt64, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SInt32Type}, typename, ::Context)   = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int32, Val{:zigzag}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SInt64Type}, typename, ::Context)   = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int64, Val{:zigzag}))"
+function jl_type_tagged_oneof_decode_expr(f::FieldType{ReferencedType}, typename, ctx::Context)
+      _is_message(f.type, ctx) && return "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, Ref{$(jl_typename(f.type, ctx))}))"
+      return "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, $(jl_typename(f.type, ctx))))"
+end
+
 function field_decode_expr(io, field::OneOfType, i, ctx::Context)
     field_name = jl_fieldname(field)
-    for (j, case) in enumerate(field.fields)
-        j += i
-        println(io, "    " ^ 2, j == 2 ? "if " : "elseif ", "field_number == ", string(case.number))
-        println(io, "    " ^ 3, field_name, " = ", jl_type_oneof_decode_expr(case, ctx))
+    if ctx.options.tagged_oneofs
+        typename = string("var\"", ctx._toplevel_raw_name[], ".", replace(titlecase(field.name), "_"=>""), "\"")
+        for (j, case) in enumerate(field.fields)
+            j += i
+            print(io, "    " ^ 2, j == 2 ? "if     " : "elseif ", "field_number == ", string(case.number), "; ")
+            println(io, field_name, " = ", jl_type_tagged_oneof_decode_expr(case, typename, ctx))
+        end
+    else
+        for (j, case) in enumerate(field.fields)
+            j += i
+            print(io, "    " ^ 2, j == 2 ? "if     " : "elseif ", "field_number == ", string(case.number), "; ")
+            println(io, field_name, " = ", jl_type_oneof_decode_expr(case, ctx))
+        end
     end
     return nothing
 end

--- a/src/codegen/decode_methods.jl
+++ b/src/codegen/decode_methods.jl
@@ -62,14 +62,14 @@ function jl_type_oneof_decode_expr(f::FieldType{ReferencedType}, ctx::Context)
       return "OneOf(:$(jl_fieldname(f)), PB.decode(d, $(jl_typename(f.type, ctx))))"
 end
 
-jl_type_tagged_oneof_decode_expr(f::FieldType, typename, ctx::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, $(jl_typename(f.type, ctx))))"
-jl_type_tagged_oneof_decode_expr(f::GroupType, typename, ctx::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Ref{$(jl_typename(f.type, ctx))}, Val{:group}))"
-jl_type_tagged_oneof_decode_expr(f::FieldType{SFixed32Type}, typename, ::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int32, Val{:fixed}))"
-jl_type_tagged_oneof_decode_expr(f::FieldType{SFixed64Type}, typename, ::Context) = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int64, Val{:fixed}))"
-jl_type_tagged_oneof_decode_expr(f::FieldType{Fixed32Type}, typename, ::Context)  = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, UInt32, Val{:fixed}))"
-jl_type_tagged_oneof_decode_expr(f::FieldType{Fixed64Type}, typename, ::Context)  = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, UInt64, Val{:fixed}))"
-jl_type_tagged_oneof_decode_expr(f::FieldType{SInt32Type}, typename, ::Context)   = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int32, Val{:zigzag}))"
-jl_type_tagged_oneof_decode_expr(f::FieldType{SInt64Type}, typename, ::Context)   = "$(typename)(Val(:$(jl_fieldname(f))), decode(d, Int64, Val{:zigzag}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType, typename, ctx::Context) = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, $(jl_typename(f.type, ctx))))"
+jl_type_tagged_oneof_decode_expr(f::GroupType, typename, ctx::Context) = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, Ref{$(jl_typename(f.type, ctx))}, Val{:group}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SFixed32Type}, typename, ::Context) = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, Int32, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SFixed64Type}, typename, ::Context) = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, Int64, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{Fixed32Type}, typename, ::Context)  = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, UInt32, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{Fixed64Type}, typename, ::Context)  = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, UInt64, Val{:fixed}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SInt32Type}, typename, ::Context)   = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, Int32, Val{:zigzag}))"
+jl_type_tagged_oneof_decode_expr(f::FieldType{SInt64Type}, typename, ::Context)   = "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, Int64, Val{:zigzag}))"
 function jl_type_tagged_oneof_decode_expr(f::FieldType{ReferencedType}, typename, ctx::Context)
       _is_message(f.type, ctx) && return "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, Ref{$(jl_typename(f.type, ctx))}))"
       return "$(typename)(Val(:$(jl_fieldname(f))), PB.decode(d, $(jl_typename(f.type, ctx))))"
@@ -121,8 +121,9 @@ function generate_decode_method(io, t::MessageType, ctx::Context)
     for (i, field) in enumerate(t.fields)
         field_decode_expr(io, field, i, ctx)
     end
-    has_fields && println(io, "        else")
-    println(io, "    " ^ (3 - !has_fields), "Base.skip(d, wire_type)")
+    print(io, "        ")
+    has_fields && print(io, "else   ")
+    println(io, "Base.skip(d, wire_type)")
     has_fields && println(io, "        end")
     println(io, "    end")
     print(io, "    return ")

--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -69,13 +69,15 @@ function print_field_encode_expr(io, f::GroupType, ctx::Context)
 end
 
 function print_field_encode_expr(io, fs::OneOfType, ctx::Context)
-    println(io, "    if isnothing(x.$(safename(fs)));")
+    x_field = "x.$(safename(fs))"
+    println(io, "    if isnothing($(x_field));")
     if ctx.options.tagged_oneofs
-        for (i, f) in enumerate(fs.fields)
+        tag_infos = _tagged_oneof_field_infos(fs.fields, ctx)
+        for (f, info) in zip(fs.fields, tag_infos)
             V = _decoding_val_type(f.type)
             V = isempty(V) ? "" : ", Val{$V}"
-            print(io, "    elseif ", "PB.tag(x.$(safename(fs))) == UInt8(", i, "); ")
-            println(io, "PB.encode(e, $(string(f.number)), PB.active_value(x.$(safename(fs)))::$(jl_typename(f, ctx))$V)")
+            print(io, "    elseif ", "Base.getfield($(x_field), :tag) == UInt8(", info.idx, "); ")
+            println(io, "PB.encode(e, $(string(f.number)), ", _tagged_getfield(info, x_field), "$V)")
         end
     else
         for f in fs.fields
@@ -112,20 +114,22 @@ function print_field_encoded_size_expr(io, f::GroupType, ::Context)
 end
 
 function print_field_encoded_size_expr(io, fs::OneOfType, ctx::Context)
-    println(io, "    if     isnothing(x.$(safename(fs)));")
+    x_field = "x.$(safename(fs))"
+    println(io, "    if     isnothing($(x_field));")
     if ctx.options.tagged_oneofs
-        for (i, f) in enumerate(fs.fields)
+        tag_infos = _tagged_oneof_field_infos(fs.fields, ctx)
+        for (f, info) in zip(fs.fields, tag_infos)
             V = _decoding_val_type(f.type)
             V = isempty(V) ? "" : ", Val{$V}"
-            print(io, "    elseif ", "PB.tag(x.$(safename(fs))) == UInt8(", i, "); ")
-            println(io, "encoded_size += PB._encoded_size(PB.active_value(x.$(safename(fs)))::$(jl_typename(f, ctx)), $(string(f.number))$V)")
+            print(io, "    elseif ", "Base.getfield($(x_field), :tag) == UInt8(", info.idx, "); ")
+            println(io, "encoded_size += PB._encoded_size(", _tagged_getfield(info, x_field),", $(string(f.number))$V)")
         end
     else
         for f in fs.fields
             V = _decoding_val_type(f.type)
             V = isempty(V) ? "" : ", Val{$V}"
-            print(io, "    elseif ", "x.$(safename(fs)).name === :", jl_fieldname(f), "; ")
-            println(io, "encoded_size += PB._encoded_size(x.$(safename(fs))[]::$(jl_typename(f, ctx)), $(string(f.number))$V)")
+            print(io, "    elseif ", "$(x_field).name === :", jl_fieldname(f), "; ")
+            println(io, "encoded_size += PB._encoded_size($(x_field)[]::$(jl_typename(f, ctx)), $(string(f.number))$V)")
         end
     end
     println(io, "    end")

--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -70,11 +70,20 @@ end
 
 function print_field_encode_expr(io, fs::OneOfType, ctx::Context)
     println(io, "    if isnothing(x.$(safename(fs)));")
-    for f in fs.fields
-        V = _decoding_val_type(f.type)
-        V = isempty(V) ? "" : ", Val{$V}"
-        println(io, "    elseif ", "x.$(safename(fs)).name === :", jl_fieldname(f))
-        println(io, "    " ^ 2, "PB.encode(e, $(string(f.number)), x.$(safename(fs))[]::$(jl_typename(f, ctx))$V)")
+    if ctx.options.tagged_oneofs
+        for (i, f) in enumerate(fs.fields)
+            V = _decoding_val_type(f.type)
+            V = isempty(V) ? "" : ", Val{$V}"
+            print(io, "    elseif ", "PB.tag(x.$(safename(fs))) == UInt8(", i, "); ")
+            println(io, "PB.encode(e, $(string(f.number)), PB.active_value(x.$(safename(fs)))::$(jl_typename(f, ctx))$V)")
+        end
+    else
+        for f in fs.fields
+            V = _decoding_val_type(f.type)
+            V = isempty(V) ? "" : ", Val{$V}"
+            print(io, "    elseif ", "x.$(safename(fs)).name === :", jl_fieldname(f), "; ")
+            println(io, "PB.encode(e, $(string(f.number)), x.$(safename(fs))[]::$(jl_typename(f, ctx))$V)")
+        end
     end
     println(io, "    end")
 end
@@ -103,12 +112,21 @@ function print_field_encoded_size_expr(io, f::GroupType, ::Context)
 end
 
 function print_field_encoded_size_expr(io, fs::OneOfType, ctx::Context)
-    println(io, "    if isnothing(x.$(safename(fs)));")
-    for f in fs.fields
-        V = _decoding_val_type(f.type)
-        V = isempty(V) ? "" : ", Val{$V}"
-        println(io, "    elseif ", "x.$(safename(fs)).name === :", jl_fieldname(f))
-        println(io, "    " ^ 2, "encoded_size += PB._encoded_size(x.$(safename(fs))[]::$(jl_typename(f, ctx)), $(string(f.number))$V)")
+    println(io, "    if     isnothing(x.$(safename(fs)));")
+    if ctx.options.tagged_oneofs
+        for (i, f) in enumerate(fs.fields)
+            V = _decoding_val_type(f.type)
+            V = isempty(V) ? "" : ", Val{$V}"
+            print(io, "    elseif ", "PB.tag(x.$(safename(fs))) == UInt8(", i, "); ")
+            println(io, "encoded_size += PB._encoded_size(PB.active_value(x.$(safename(fs)))::$(jl_typename(f, ctx)), $(string(f.number))$V)")
+        end
+    else
+        for f in fs.fields
+            V = _decoding_val_type(f.type)
+            V = isempty(V) ? "" : ", Val{$V}"
+            print(io, "    elseif ", "x.$(safename(fs)).name === :", jl_fieldname(f), "; ")
+            println(io, "encoded_size += PB._encoded_size(x.$(safename(fs))[]::$(jl_typename(f, ctx)), $(string(f.number))$V)")
+        end
     end
     println(io, "    end")
 end

--- a/src/codegen/names.jl
+++ b/src/codegen/names.jl
@@ -67,9 +67,18 @@ function _safename(name::AbstractString)
 end
 
 abstract_type_name(name::AbstractString) = string("var\"##Abstract#", name, "\"")
+abstract_tagged_oneof_type_name(field::OneOfType, ctx::Context) = abstract_tagged_oneof_type_name(field.name, ctx._toplevel_raw_name[])
+abstract_tagged_oneof_type_name(field::AbstractString, ctx::Context) = abstract_tagged_oneof_type_name(field, ctx._toplevel_raw_name[])
+function abstract_tagged_oneof_type_name(field::AbstractString, parent::AbstractString)
+    string("var\"##Abstract#", parent, ".", replace(titlecase(field), "_"=>""), "\"")
+end
 
 jl_fieldname(@nospecialize(f::AbstractProtoFieldType)) = _safename(f.name)
 jl_fieldname(f::GroupType) = _safename(f.field_name)
+
+jl_tagged_type_name(field::OneOfType, parent) = string("var\"", parent, ".", replace(titlecase(field.name), "_"=>""), "\"")
+jl_tagged_type_name(fieldname::AbstractString, parent) = string("var\"", parent, ".", replace(titlecase(fieldname), "_"=>""), "\"")
+jl_tagged_type_name(field::OneOfType, ctx::Context) = string("var\"", ctx._toplevel_raw_name[], ".", replace(titlecase(field.name), "_"=>""), "\"")
 
 _safe_namespace_string(ns::AbstractVector{<:AbstractString}) = string("var\"#$(first(ns))\"", '.', join(@view(ns[2:end]), '.'))
 

--- a/src/codegen/tagged_oneofs.jl
+++ b/src/codegen/tagged_oneofs.jl
@@ -1,0 +1,48 @@
+function maybe_generate_tagged_oneofs(io, t::MessageType, ctx::Context)
+    !(t.has_oneof_field && ctx.options.tagged_oneofs) && return nothing
+    for field in fields
+        field isa OneOfType || continue
+        _generate_tagged_oneof(io, t, field::OneOfType, ctx)
+    end
+    return nothing
+end
+
+function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
+    println(io, "struct ",
+        t.name, replace(titlecase(f.name), "_"=>""),
+        t.is_self_referential ? "{T}" : "",
+        " <: AbstractOneOf",
+    )
+    println(io, "    tag::", length(t.fields) > 256 ? "UInt16", "UInt8")
+    println(io, "    bit::Union{Nothing, ", ,"}")
+    println(io, "    ptr::Union{Nothing, ", ,"}")
+end
+
+function _split_oneof_types(fields)
+    bittypes = NTuple{2,String}[]
+    ptrtypes = NTuple{2,String}[]
+
+    for f in fields
+        f.
+    end
+end
+
+query_isbits!(t::ReferencedType, ctx) = query_isbits!(_get_referenced_type(t, ctx))
+query_isbits!(t::AbstractProtoNumericType, ctx) = true
+query_isbits!(t::AbstractProtoNumericType, ctx) = true
+query_isbits!(t::EnumType, ctx) = true
+query_isbits!(t::StringType, ctx) = false
+query_isbits!(t::BytesType, ctx) = false
+query_isbits!(t::MapType, ctx) = false
+query_isbits!(f::AbstractProtoFieldType, ctx) = !_is_repeated_field(f) && query_isbits!(f.type)
+query_isbits!(f::GroupType, ctx) = !_is_repeated_field(f) && query_isbits!(t.type, ctx)
+query_isbits!(t::OneOfType, ctx) = all(query_isbits!, t.fields)
+function query_isbits!(t::MessageType, ctx)
+    out = t.isbits[]
+    if out == UNKNOWN
+        out = (!t.is_self_referential[] && all(query_isbits!, t.fields)) ? ISBITS : NONISBITS
+        t.isbits[] = out
+    end
+
+    return out == ISBITS
+end

--- a/src/codegen/tagged_oneofs.jl
+++ b/src/codegen/tagged_oneofs.jl
@@ -1,48 +1,106 @@
+abstract type TaggedOneOf end
+
 function maybe_generate_tagged_oneofs(io, t::MessageType, ctx::Context)
     !(t.has_oneof_field && ctx.options.tagged_oneofs) && return nothing
-    for field in fields
+    for field in t.fields
         field isa OneOfType || continue
         _generate_tagged_oneof(io, t, field::OneOfType, ctx)
+        println(io)
     end
     return nothing
 end
 
 function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
-    println(io, "struct ",
-        t.name, replace(titlecase(f.name), "_"=>""),
-        t.is_self_referential ? "{T}" : "",
-        " <: AbstractOneOf",
-    )
-    println(io, "    tag::", length(t.fields) > 256 ? "UInt16", "UInt8")
-    println(io, "    bit::Union{Nothing, ", ,"}")
-    println(io, "    ptr::Union{Nothing, ", ,"}")
+    (; bitstypes, ptrstypes, isbits_flags) = _split_oneof_types(f.fields, ctx)
+
+    typename = string("var\"", t.name, ".", replace(titlecase(f.name), "_"=>""), "\"")
+    print(io, "struct ", typename)
+    if t.is_self_referential[] # || appears_in_cycle
+        print(io, "{T<:", abstract_type_name(t.name), "}")
+    end
+    println(io, " <: TaggedOneOf")
+    println(io, "    tag::UInt8")
+
+    print(io, "    bit::Union{Nothing")
+    for (name, type) in bitstypes
+        print(io, ", ")
+        print(io, type)
+    end
+    println(io, "}")
+
+    print(io, "    ptr::Union{Nothing")
+    for (name, type) in ptrstypes
+        print(io, ", ")
+        print(io, type)
+    end
+    println(io, "}")
+    println(io, "end")
+
+    for (i, (isbits_flag, f)) in enumerate(zip(isbits_flags, f.fields))
+        fieldname = jl_fieldname(f)
+        fieldtype = jl_typename(f, ctx)
+        print(io, typename, "(::Val{", repr(Symbol(jl_fieldname(f))), "}, x)")
+        print(io, " = ", typename, "(UInt8(", i, "), ")
+        if isbits_flag
+            println(io, "convert(", fieldtype, ", x), nothing)")
+        else
+            println(io, "nothing, convert(", fieldtype, ", x))")
+        end
+    end
+
+    for (isbits_flag, f) in zip(isbits_flags, f.fields)
+        fieldname = jl_fieldname(f)
+        fieldtype = jl_typename(f, ctx)
+        print(io, "PB.unsafe_getproperty(x::", typename, ", ::Val{", repr(Symbol(jl_fieldname(f))), "})")
+        println(io, " = Base.getfield(x, :", isbits_flag ? "bit" : "ptr", ")::", fieldtype)
+    end
+
+    println(io, "function PB.active_name(f::F, x::", typename, ") where {F}")
+    println(io, "    tag = x.tag")
+    for (i, f) in enumerate(f.fields)
+        print(io, "    ")
+        i > 1 ? print(io, "elseif") : print(io, "if    ")
+        println(io, " tag == UInt8(", i, "); return f(Val(", repr(Symbol(jl_fieldname(f))), "))")
+    end
+    println(io, "    else   # unreachable")
+    println(io, "    end")
+    println(io, "end")
+
+    println(io, "function PB.active_value(f::F, x::", typename, ") where {F}")
+    println(io, "    tag = x.tag")
+    for (i, f) in enumerate(f.fields)
+        print(io, "    ")
+        i > 1 ? print(io, "elseif") : print(io, "if    ")
+        println(io, " tag == UInt8(", i, "); return f(PB.unsafe_getproperty(x, Val(", repr(Symbol(jl_fieldname(f))), ")))")
+    end
+    println(io, "    else   # unreachable")
+    println(io, "    end")
+    println(io, "end")
+    return nothing
 end
 
-function _split_oneof_types(fields)
-    bittypes = NTuple{2,String}[]
-    ptrtypes = NTuple{2,String}[]
+function _split_oneof_types(fields, ctx)
+    bitstypes = NTuple{2,String}[]
+    ptrstypes = NTuple{2,String}[]
+    isbits_flags = Bool[]
 
     for f in fields
-        f.
+        tinfo = query_typeinfo!(f, ctx)
+        if tinfo.isbits && tinfo.size <= 16
+            push!(bitstypes, (jl_fieldname(f), jl_typename(f, ctx)))
+            push!(isbits_flags, true)
+        else
+            push!(ptrstypes, (jl_fieldname(f), jl_typename(f, ctx)))
+            push!(isbits_flags, false)
+        end
     end
+    return (; bitstypes, ptrstypes, isbits_flags)
 end
 
-query_isbits!(t::ReferencedType, ctx) = query_isbits!(_get_referenced_type(t, ctx))
-query_isbits!(t::AbstractProtoNumericType, ctx) = true
-query_isbits!(t::AbstractProtoNumericType, ctx) = true
-query_isbits!(t::EnumType, ctx) = true
-query_isbits!(t::StringType, ctx) = false
-query_isbits!(t::BytesType, ctx) = false
-query_isbits!(t::MapType, ctx) = false
-query_isbits!(f::AbstractProtoFieldType, ctx) = !_is_repeated_field(f) && query_isbits!(f.type)
-query_isbits!(f::GroupType, ctx) = !_is_repeated_field(f) && query_isbits!(t.type, ctx)
-query_isbits!(t::OneOfType, ctx) = all(query_isbits!, t.fields)
-function query_isbits!(t::MessageType, ctx)
-    out = t.isbits[]
-    if out == UNKNOWN
-        out = (!t.is_self_referential[] && all(query_isbits!, t.fields)) ? ISBITS : NONISBITS
-        t.isbits[] = out
-    end
+function unsafe_getproperty end
+function active_name end
+function active_value end
 
-    return out == ISBITS
-end
+active_value(x::TaggedOneOf) = active_value(identity, x)
+active_name(x::TaggedOneOf) = active_name(identity, x)
+(x::TaggedOneOf)(; kw...) = x(Val(only(kw)[1]), Val(only(kw)[2]))

--- a/src/codegen/tagged_oneofs.jl
+++ b/src/codegen/tagged_oneofs.jl
@@ -27,26 +27,49 @@ function maybe_generate_tagged_oneofs(io, t::MessageType, ctx::Context)
     return nothing
 end
 
+function maybe_generate_non_cyclic_tagged_oneofs(io, t::MessageType, ctx::Context)
+    !(t.has_oneof_field && ctx.options.tagged_oneofs) && return nothing
+    deps = get(ctx._types_and_oneofs_requiring_type_params, t.name, nothing)
+    cyclic_oneofs = isnothing(deps) ? Set{String}() : Set{String}(name for (isoneof, name) in deps if isoneof)
+    for field in t.fields
+        field isa OneOfType || continue
+        field.name in cyclic_oneofs && continue
+        _generate_tagged_oneof(io, t, field::OneOfType, ctx)
+        println(io)
+    end
+    return nothing
+end
+
+function maybe_generate_cyclic_tagged_oneofs(io, t::MessageType, ctx::Context)
+    !(t.has_oneof_field && ctx.options.tagged_oneofs) && return nothing
+    deps = get(ctx._types_and_oneofs_requiring_type_params, t.name, nothing)
+    cyclic_oneofs = isnothing(deps) ? Set{String}() : Set{String}(name for (isoneof, name) in deps if isoneof)
+    for field in t.fields
+        field isa OneOfType || continue
+        field.name in cyclic_oneofs || continue
+        _generate_tagged_oneof(io, t, field::OneOfType, ctx)
+        println(io)
+    end
+    return nothing
+end
+
 _tagged_getfield(info, ident) = string("Base.getfield(", ident,", :", info.inline ? "bit" : "ptr", ")::", info.type)
 
 function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
     field_infos = _tagged_oneof_field_infos(f.fields, ctx)
-    typename = string("var\"", t.name, ".", replace(titlecase(f.name), "_"=>""), "\"")
+    typename = jl_tagged_type_name(f, t.name)
     seen = Set{String}()
 
     print(io, "struct ", typename)
-    if t.is_self_referential[] # || appears_in_cycle
-        print(io, "{T<:", abstract_type_name(t.name), "}")
-    end
     println(io, " <: PB.TaggedOneOf")
     println(io, "    tag::UInt8")
 
     print(io, "    bit::Union{Nothing")
     for info in field_infos
         info.inline || continue
-        get!(seen.dict, info.type) do
+        get!(seen.dict, info.type_toplevel) do
             print(io, ",")
-            print(io, info.type)
+            print(io, info.type_toplevel)
             nothing
         end
     end
@@ -56,9 +79,9 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
     print(io, "    ptr::Union{Nothing")
     for info in field_infos
         info.inline && continue
-        get!(seen.dict, info.type) do
+        get!(seen.dict, info.type_toplevel) do
             print(io, ",")
-            print(io, info.type)
+            print(io, info.type_toplevel)
             nothing
         end
     end
@@ -112,11 +135,19 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
 end
 
 function _tagged_oneof_field_infos(fields, ctx)
-    field_infos = @NamedTuple{idx::Int, name::String, type::String, inline::Bool}[]
+    field_infos = @NamedTuple{idx::Int, name::String, type_toplevel::String, type::String, inline::Bool}[]
     idx = 1
     for f in fields
         tinfo = query_typeinfo!(f, ctx)
-        push!(field_infos, (; idx, name=jl_fieldname(f), type=jl_typename(f, ctx), inline=tinfo.isbits && tinfo.size <= 16))
+        name = jl_fieldname(f)
+        type = jl_typename(f, ctx)
+        inline = tinfo.isbits && tinfo.size <= 16
+        if f isa FieldType{ReferencedType}
+            type_toplevel = reconstruct_parametrized_stub_type_name(f.type, ctx)
+        else
+            type_toplevel = type
+        end
+        push!(field_infos, (; idx, name, type_toplevel, type, inline))
         idx += 1
     end
     return field_infos

--- a/src/codegen/tagged_oneofs.jl
+++ b/src/codegen/tagged_oneofs.jl
@@ -27,10 +27,13 @@ function maybe_generate_tagged_oneofs(io, t::MessageType, ctx::Context)
     return nothing
 end
 
-function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
-    (; bitstypes, ptrstypes, isbits_flags) = _split_oneof_types(f.fields, ctx)
+_tagged_getfield(info, ident) = string("Base.getfield(", ident,", :", info.inline ? "bit" : "ptr", ")::", info.type)
 
+function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
+    field_infos = _tagged_oneof_field_infos(f.fields, ctx)
     typename = string("var\"", t.name, ".", replace(titlecase(f.name), "_"=>""), "\"")
+    seen = Set{String}()
+
     print(io, "struct ", typename)
     if t.is_self_referential[] # || appears_in_cycle
         print(io, "{T<:", abstract_type_name(t.name), "}")
@@ -39,53 +42,57 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
     println(io, "    tag::UInt8")
 
     print(io, "    bit::Union{Nothing")
-    for (name, type) in bitstypes
-        print(io, ", ")
-        print(io, type)
+    for info in field_infos
+        info.inline || continue
+        get!(seen.dict, info.type) do
+            print(io, ",")
+            print(io, info.type)
+            nothing
+        end
     end
     println(io, "}")
 
+    empty!(seen)
     print(io, "    ptr::Union{Nothing")
-    for (name, type) in ptrstypes
-        print(io, ", ")
-        print(io, type)
+    for info in field_infos
+        info.inline && continue
+        get!(seen.dict, info.type) do
+            print(io, ",")
+            print(io, info.type)
+            nothing
+        end
     end
     println(io, "}")
     println(io, "end")
 
-    for (i, (isbits_flag, f)) in enumerate(zip(isbits_flags, f.fields))
-        fieldname = jl_fieldname(f)
-        fieldtype = jl_typename(f, ctx)
-        print(io, typename, "(::Val{", repr(Symbol(fieldname)), "}, x)")
-        print(io, " = ", typename, "(UInt8(", i, "), ")
-        if isbits_flag
-            println(io, "convert(", fieldtype, ", x), nothing)")
+    for info in field_infos
+        print(io, typename, "(::Val{:", info.name, "}, x)")
+        print(io, " = ", typename, "(UInt8(", info.idx, "), ")
+        if info.inline
+            println(io, "convert(", info.type, ", x), nothing)")
         else
-            println(io, "nothing, convert(", fieldtype, ", x))")
+            println(io, "nothing, convert(", info.type, ", x))")
         end
     end
 
-    for (isbits_flag, f) in zip(isbits_flags, f.fields)
-        fieldname = jl_fieldname(f)
-        fieldtype = jl_typename(f, ctx)
-        print(io, "PB.unsafe_getproperty(x::", typename, ", ::Val{", repr(Symbol(fieldname)), "})")
-        println(io, " = Base.getfield(x, :", isbits_flag ? "bit" : "ptr", ")::", fieldtype)
+    for info in field_infos
+        print(io, "PB.unsafe_getproperty(x::", typename, ", ::Val{:", info.name, "})")
+        println(io, " = ", _tagged_getfield(info, "x"))
     end
 
     print(io, "PB.field_to_tag(::Type{", typename, "}) = (;")
-    for (i, f) in enumerate(f.fields)
-        fieldname = jl_fieldname(f)
-        i > 1 && print(io, ", ")
-        print(io, fieldname, " = UInt8(", i,")")
+    for info in field_infos
+        info.idx > 1 && print(io, ", ")
+        print(io, info.name, " = UInt8(", info.idx,")")
     end
     println(io, ")")
 
     println(io, "function PB.active_name(f::F, x::", typename, ") where {F}")
     println(io, "    tag = getfield(x, :tag)")
-    for (i, f) in enumerate(f.fields)
+    for info in field_infos
         print(io, "    ")
-        i > 1 ? print(io, "elseif") : print(io, "if    ")
-        println(io, " tag == UInt8(", i, "); return f(Val(", repr(Symbol(jl_fieldname(f))), "))")
+        info.idx > 1 ? print(io, "elseif") : print(io, "if    ")
+        println(io, " tag == UInt8(", info.idx, "); return f(Val(:", info.name, "))")
     end
     println(io, "    else   PB.throw_bad_tag(", typename,", tag)")
     println(io, "    end")
@@ -93,10 +100,10 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
 
     println(io, "function PB.active_value(f::F, x::", typename, ") where {F}")
     println(io, "    tag = getfield(x, :tag)")
-    for (i, f) in enumerate(f.fields)
+    for info in field_infos
         print(io, "    ")
-        i > 1 ? print(io, "elseif") : print(io, "if    ")
-        println(io, " tag == UInt8(", i, "); return f(PB.unsafe_getproperty(x, Val(", repr(Symbol(jl_fieldname(f))), ")))")
+        info.idx > 1 ? print(io, "elseif") : print(io, "if    ")
+        println(io, " tag == UInt8(", info.idx, "); return f(", _tagged_getfield(info, "x"), ")")
     end
     println(io, "    else   PB.throw_bad_tag(", typename,", tag)")
     println(io, "    end")
@@ -104,21 +111,14 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
     return nothing
 end
 
-function _split_oneof_types(fields, ctx)
-    bitstypes = NTuple{2,String}[]
-    ptrstypes = NTuple{2,String}[]
-    isbits_flags = Bool[]
-
+function _tagged_oneof_field_infos(fields, ctx)
+    field_infos = @NamedTuple{idx::Int, name::String, type::String, inline::Bool}[]
+    idx = 1
     for f in fields
         tinfo = query_typeinfo!(f, ctx)
-        if tinfo.isbits && tinfo.size <= 16
-            push!(bitstypes, (jl_fieldname(f), jl_typename(f, ctx)))
-            push!(isbits_flags, true)
-        else
-            push!(ptrstypes, (jl_fieldname(f), jl_typename(f, ctx)))
-            push!(isbits_flags, false)
-        end
+        push!(field_infos, (; idx, name=jl_fieldname(f), type=jl_typename(f, ctx), inline=tinfo.isbits && tinfo.size <= 16))
+        idx += 1
     end
-    return (; bitstypes, ptrstypes, isbits_flags)
+    return field_infos
 end
 

--- a/src/codegen/tagged_oneofs.jl
+++ b/src/codegen/tagged_oneofs.jl
@@ -1,5 +1,22 @@
 abstract type TaggedOneOf end
 
+function field_to_tag end
+function unsafe_getproperty end
+function active_name end
+function active_value end
+
+@noinline throw_not_set(::Type{T}, f) where {T<:TaggedOneOf} = error("Field `$(f)` is not active for type `$(T)`")
+@noinline throw_bad_tag(::Type{T}, t) where {T<:TaggedOneOf} = error("Tag `$(f)` is not valid for type `$(T)`")
+@inline Base.propertynames(::Type{T}) where {T<:TaggedOneOf} = keys(field_to_tag(T))
+@inline Base.getproperty(x::T, sym::Symbol) where {T<:TaggedOneOf} = (field_to_tag(T)[sym])::UInt8 != getfield(x, :tag)::UInt8 ? throw_not_set(T, sym) : unsafe_getproperty(x, Val(sym))
+Base.show(io::IO, x::T) where {T<:TaggedOneOf} = println(io, string(T), "(", active_name(x), " = ", repr(active_value(x)), ")")
+
+_name_from_val(::Val{name}) where {name} = name
+@inline active_value(x::TaggedOneOf) = active_value(identity, x)
+@inline active_name(x::TaggedOneOf) = active_name(_name_from_val, x)
+(::Type{T})(; kw...) where {T<:TaggedOneOf} = T(Val(only(kw)[1]), only(kw)[2])
+@inline tag(x::T) where {T<:TaggedOneOf} = getfield(x, :tag)::UInt8
+
 function maybe_generate_tagged_oneofs(io, t::MessageType, ctx::Context)
     !(t.has_oneof_field && ctx.options.tagged_oneofs) && return nothing
     for field in t.fields
@@ -18,7 +35,7 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
     if t.is_self_referential[] # || appears_in_cycle
         print(io, "{T<:", abstract_type_name(t.name), "}")
     end
-    println(io, " <: TaggedOneOf")
+    println(io, " <: PB.TaggedOneOf")
     println(io, "    tag::UInt8")
 
     print(io, "    bit::Union{Nothing")
@@ -39,7 +56,7 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
     for (i, (isbits_flag, f)) in enumerate(zip(isbits_flags, f.fields))
         fieldname = jl_fieldname(f)
         fieldtype = jl_typename(f, ctx)
-        print(io, typename, "(::Val{", repr(Symbol(jl_fieldname(f))), "}, x)")
+        print(io, typename, "(::Val{", repr(Symbol(fieldname)), "}, x)")
         print(io, " = ", typename, "(UInt8(", i, "), ")
         if isbits_flag
             println(io, "convert(", fieldtype, ", x), nothing)")
@@ -51,29 +68,37 @@ function _generate_tagged_oneof(io, t::MessageType, f::OneOfType, ctx::Context)
     for (isbits_flag, f) in zip(isbits_flags, f.fields)
         fieldname = jl_fieldname(f)
         fieldtype = jl_typename(f, ctx)
-        print(io, "PB.unsafe_getproperty(x::", typename, ", ::Val{", repr(Symbol(jl_fieldname(f))), "})")
+        print(io, "PB.unsafe_getproperty(x::", typename, ", ::Val{", repr(Symbol(fieldname)), "})")
         println(io, " = Base.getfield(x, :", isbits_flag ? "bit" : "ptr", ")::", fieldtype)
     end
 
+    print(io, "PB.field_to_tag(::Type{", typename, "}) = (;")
+    for (i, f) in enumerate(f.fields)
+        fieldname = jl_fieldname(f)
+        i > 1 && print(io, ", ")
+        print(io, fieldname, " = UInt8(", i,")")
+    end
+    println(io, ")")
+
     println(io, "function PB.active_name(f::F, x::", typename, ") where {F}")
-    println(io, "    tag = x.tag")
+    println(io, "    tag = getfield(x, :tag)")
     for (i, f) in enumerate(f.fields)
         print(io, "    ")
         i > 1 ? print(io, "elseif") : print(io, "if    ")
         println(io, " tag == UInt8(", i, "); return f(Val(", repr(Symbol(jl_fieldname(f))), "))")
     end
-    println(io, "    else   # unreachable")
+    println(io, "    else   PB.throw_bad_tag(", typename,", tag)")
     println(io, "    end")
     println(io, "end")
 
     println(io, "function PB.active_value(f::F, x::", typename, ") where {F}")
-    println(io, "    tag = x.tag")
+    println(io, "    tag = getfield(x, :tag)")
     for (i, f) in enumerate(f.fields)
         print(io, "    ")
         i > 1 ? print(io, "elseif") : print(io, "if    ")
         println(io, " tag == UInt8(", i, "); return f(PB.unsafe_getproperty(x, Val(", repr(Symbol(jl_fieldname(f))), ")))")
     end
-    println(io, "    else   # unreachable")
+    println(io, "    else   PB.throw_bad_tag(", typename,", tag)")
     println(io, "    end")
     println(io, "end")
     return nothing
@@ -97,10 +122,3 @@ function _split_oneof_types(fields, ctx)
     return (; bitstypes, ptrstypes, isbits_flags)
 end
 
-function unsafe_getproperty end
-function active_name end
-function active_value end
-
-active_value(x::TaggedOneOf) = active_value(identity, x)
-active_name(x::TaggedOneOf) = active_name(identity, x)
-(x::TaggedOneOf)(; kw...) = x(Val(only(kw)[1]), Val(only(kw)[2]))

--- a/src/codegen/toplevel_definitions.jl
+++ b/src/codegen/toplevel_definitions.jl
@@ -40,7 +40,9 @@ function generate_struct_field(io, field::OneOfType, ctx::Context, type_params)
     field_name = jl_fieldname(field)
     type_param = get(type_params.oneofs, field.name, nothing)
 
-    if !isnothing(type_param)
+    if ctx.options.tagged_oneofs
+        type_name = jl_typename(field, ctx)
+    elseif !isnothing(type_param)
         type_name = type_param.param
     else
         type_name = _get_oneof_type_bound(field, ctx, type_params)
@@ -77,6 +79,7 @@ end
 codegen(t::AbstractProtoType, ctx::Context) = codegen(stdout, t, ctx::Context)
 
 function codegen(io, t::MessageType, ctx::Context)
+    maybe_generate_tagged_oneofs(io, t, ctx)
     generate_struct(io, t, ctx)
     maybe_generate_kwarg_constructor_method(io, t, ctx)
     maybe_generate_deprecation(io, t)

--- a/src/codegen/toplevel_definitions.jl
+++ b/src/codegen/toplevel_definitions.jl
@@ -40,10 +40,10 @@ function generate_struct_field(io, field::OneOfType, ctx::Context, type_params)
     field_name = jl_fieldname(field)
     type_param = get(type_params.oneofs, field.name, nothing)
 
-    if ctx.options.tagged_oneofs
-        type_name = jl_typename(field, ctx)
-    elseif !isnothing(type_param)
+    if !isnothing(type_param)
         type_name = type_param.param
+    elseif ctx.options.tagged_oneofs
+        type_name = jl_typename(field, ctx)
     else
         type_name = _get_oneof_type_bound(field, ctx, type_params)
     end
@@ -124,11 +124,15 @@ const B = var"##Stub#B"                # <- This is fully concrete type
 =#
 function codegen_cylic_stub(io, t::MessageType, ctx::Context)
     @assert t.name in keys(ctx._types_and_oneofs_requiring_type_params)
+
+    maybe_generate_non_cyclic_tagged_oneofs(io, t, ctx)
+
     # After we're done with this struct, all the subsequent definitions can use it
     # so we pop it from the list of cyclic definitions.
     abstract_base_name = pop!(ctx._remaining_cyclic_defs, t.name, "")
     type_params = get_type_params_for_cyclic(t, ctx)
     params_string = get_type_param_string(type_params)
+
 
     print(io, "struct ", stub_type_name(t.name), length(t.fields) > 0 ? params_string : " ", _maybe_subtype(abstract_base_name, ctx.options))
     # new line if there are fields, otherwise ensure that we have space before `end`
@@ -143,6 +147,7 @@ end
 # as we do for non-cyclic types.
 function codegen_cylic_rest(io, t::MessageType, ctx::Context)
     _generate_struct_alias(io, t, ctx)
+    maybe_generate_cyclic_tagged_oneofs(io, t, ctx)
     # We must define the constructor after the const is set, otherwise we get an error
     maybe_generate_constructor_for_type_alias(io, t, ctx)
     maybe_generate_kwarg_constructor_method(io, t, ctx)
@@ -273,6 +278,15 @@ function translate(io, rp::ResolvedProtoFile, file_map::Dict{String,ResolvedProt
     end
     for name in p.cyclic_definitions
         println(io, "abstract type ", abstract_type_name(name), options.common_abstract_type ? " <: AbstractProtoBufMessage" : "", " end")
+    end
+    if options.tagged_oneofs
+        for (parent, params) in ctx._types_and_oneofs_requiring_type_params
+            for (isoneof, fieldname) in params
+                if isoneof
+                    println(io, "abstract type ", abstract_tagged_oneof_type_name(fieldname, parent), " <: PB.TaggedOneOf end")
+                end
+            end
+        end
     end
 
     println(io)

--- a/src/codegen/type_info.jl
+++ b/src/codegen/type_info.jl
@@ -1,4 +1,5 @@
 const BOXED = TypeInfo(true, false, 8, 8)
+const STOP_RECURSION = TypeInfo(true, false, 0, 1)
 
 function _align(sz, al, fsz, fal)
     al = max(al, fal)
@@ -10,27 +11,27 @@ function _align(sz, al, fsz, fal)
     return sz, al
 end
 
-query_typeinfo!(t::ReferencedType, ctx) = query_typeinfo!(_get_referenced_type(t, ctx), ctx)
-query_typeinfo!(::DoubleType, ctx) = TypeInfo(true, true, 8, 8)
-query_typeinfo!(::FloatType, ctx) = TypeInfo(true, true, 4, 4)
-query_typeinfo!(::Int32Type, ctx) = TypeInfo(true, true, 4, 4)
-query_typeinfo!(::Int64Type, ctx) = TypeInfo(true, true, 8, 8)
-query_typeinfo!(::UInt32Type, ctx) = TypeInfo(true, true, 4, 4)
-query_typeinfo!(::UInt64Type, ctx) = TypeInfo(true, true, 8, 8)
-query_typeinfo!(::SInt32Type, ctx) = TypeInfo(true, true, 4, 4)
-query_typeinfo!(::SInt64Type, ctx) = TypeInfo(true, true, 8, 8)
-query_typeinfo!(::Fixed32Type, ctx) = TypeInfo(true, true, 4, 4)
-query_typeinfo!(::Fixed64Type, ctx) = TypeInfo(true, true, 8, 8)
-query_typeinfo!(::SFixed32Type, ctx) = TypeInfo(true, true, 4, 4)
-query_typeinfo!(::SFixed64Type, ctx) = TypeInfo(true, true, 8, 8)
-query_typeinfo!(::BoolType, ctx) = TypeInfo(true, true, 1, 1)
-query_typeinfo!(::StringType, ctx) = BOXED
-query_typeinfo!(::BytesType, ctx) = BOXED
-query_typeinfo!(::MapType, ctx) = BOXED
-query_typeinfo!(::EnumType, ctx) = TypeInfo(true, true, 4, 4) # Currently we only generate 4 byte enums
-query_typeinfo!(f::AbstractProtoFieldType, ctx) = _is_repeated_field(f) ? BOXED : query_typeinfo!(f.type, ctx)
-query_typeinfo!(f::GroupType, ctx) = _is_repeated_field(f) ? BOXED : query_typeinfo!(t.type, ctx)
-function query_typeinfo!(t::OneOfType, ctx) # relies on the TaggedUnion layout!
+query_typeinfo!(t::ReferencedType, ctx::Context) = query_typeinfo!(_get_referenced_type(t, ctx), ctx)
+query_typeinfo!(::DoubleType, ctx::Context) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::FloatType, ctx::Context) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::Int32Type, ctx::Context) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::Int64Type, ctx::Context) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::UInt32Type, ctx::Context) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::UInt64Type, ctx::Context) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::SInt32Type, ctx::Context) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::SInt64Type, ctx::Context) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::Fixed32Type, ctx::Context) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::Fixed64Type, ctx::Context) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::SFixed32Type, ctx::Context) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::SFixed64Type, ctx::Context) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::BoolType, ctx::Context) = TypeInfo(true, true, 1, 1)
+query_typeinfo!(::StringType, ctx::Context) = BOXED
+query_typeinfo!(::BytesType, ctx::Context) = BOXED
+query_typeinfo!(::MapType, ctx::Context) = BOXED
+query_typeinfo!(::EnumType, ctx::Context) = TypeInfo(true, true, 4, 4) # Currently we only generate 4 byte enums
+query_typeinfo!(f::AbstractProtoFieldType, ctx::Context) = _is_repeated_field(f) ? BOXED : query_typeinfo!(f.type, ctx)
+query_typeinfo!(f::GroupType, ctx::Context) = _is_repeated_field(f) ? BOXED : query_typeinfo!(t.type, ctx)
+function query_typeinfo!(t::OneOfType, ctx::Context) # relies on the TaggedUnion layout!
     bits_size = Int8(0)
     bits_alignment = Int8(0)
     ptrs_size = Int8(0)
@@ -39,7 +40,7 @@ function query_typeinfo!(t::OneOfType, ctx) # relies on the TaggedUnion layout!
     any_ptrs = false
 
     for f in t.fields
-        tinfo = query_typeinfo!(f, ctx)
+        tinfo = query_typeinfo!(f, ctx::Context)
         if tinfo.isbits && tinfo.size <= 16 # check
             any_bits = true
             bits_size = max(bits_size, tinfo.size)
@@ -69,22 +70,20 @@ function query_typeinfo!(t::OneOfType, ctx) # relies on the TaggedUnion layout!
     return out
 end
 
-function query_typeinfo!(t::MessageType, ctx)
+function query_typeinfo!(t::MessageType, ctx::Context)
     tinfo = t.tinfo[]
     if !tinfo.known
-        if t.is_self_referential[]
-            tinfo = BOXED
-        else
-            _alignment = Int8(0)
-            _size = Int8(0)
-            _isbits = !t.is_self_referential[] # && !appears_in_cycle
-            for f in t.fields
-                f_tinfo = query_typeinfo!(f, ctx)
-                _isbits &= f_tinfo.isbits
-                _size, _alignment = _align(_size, _alignment, f_tinfo.size, f_tinfo.alignment)
-            end
-            tinfo = TypeInfo(true, _isbits, _size, _alignment)
+        appears_in_cycle = t.name in keys(ctx._types_and_oneofs_requiring_type_params)
+        _alignment = Int8(0)
+        _size = Int8(0)
+        _isbits = !(t.is_self_referential[] || appears_in_cycle)
+        !_isbits && (t.tinfo[] = STOP_RECURSION)
+        for f in t.fields
+            f_tinfo = query_typeinfo!(f, ctx)
+            _isbits &= f_tinfo.isbits
+            _size, _alignment = _align(_size, _alignment, f_tinfo.size, f_tinfo.alignment)
         end
+        tinfo = TypeInfo(true, _isbits, _size, _alignment)
 
         t.tinfo[] = tinfo
     end

--- a/src/codegen/type_info.jl
+++ b/src/codegen/type_info.jl
@@ -1,0 +1,92 @@
+const BOXED = TypeInfo(true, false, 8, 8)
+
+function _align(sz, al, fsz, fal)
+    al = max(al, fal)
+    remainder = sz % fal
+    if remainder != 0
+        sz += fal - remainder
+    end
+    sz += fsz
+    return sz, al
+end
+
+query_typeinfo!(t::ReferencedType, ctx) = query_typeinfo!(_get_referenced_type(t, ctx), ctx)
+query_typeinfo!(::DoubleType, ctx) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::FloatType, ctx) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::Int32Type, ctx) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::Int64Type, ctx) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::UInt32Type, ctx) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::UInt64Type, ctx) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::SInt32Type, ctx) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::SInt64Type, ctx) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::Fixed32Type, ctx) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::Fixed64Type, ctx) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::SFixed32Type, ctx) = TypeInfo(true, true, 4, 4)
+query_typeinfo!(::SFixed64Type, ctx) = TypeInfo(true, true, 8, 8)
+query_typeinfo!(::BoolType, ctx) = TypeInfo(true, true, 1, 1)
+query_typeinfo!(::StringType, ctx) = BOXED
+query_typeinfo!(::BytesType, ctx) = BOXED
+query_typeinfo!(::MapType, ctx) = BOXED
+query_typeinfo!(::EnumType, ctx) = TypeInfo(true, true, 4, 4) # Currently we only generate 4 byte enums
+query_typeinfo!(f::AbstractProtoFieldType, ctx) = _is_repeated_field(f) ? BOXED : query_typeinfo!(f.type, ctx)
+query_typeinfo!(f::GroupType, ctx) = _is_repeated_field(f) ? BOXED : query_typeinfo!(t.type, ctx)
+function query_typeinfo!(t::OneOfType, ctx) # relies on the TaggedUnion layout!
+    bits_size = Int8(0)
+    bits_alignment = Int8(0)
+    ptrs_size = Int8(0)
+    ptrs_alignment = Int8(0)
+    any_bits = false
+    any_ptrs = false
+
+    for f in t.fields
+        tinfo = query_typeinfo!(f, ctx)
+        if tinfo.isbits && tinfo.size <= 16 # check
+            any_bits = true
+            bits_size = max(bits_size, tinfo.size)
+            bits_alignment = max(bits_alignment, tinfo.alignment)
+        else
+            any_ptrs = true
+            ptrs_size = max(ptrs_size, tinfo.size)
+            ptrs_alignment = max(ptrs_alignment, tinfo.alignment)
+        end
+
+    end
+
+    _alignment = Int8(1) # the explicit tag field in the tagged oneof struct
+    _size = Int8(1)      # the explicit tag field in the tagged oneof struct
+    if any_bits
+        # The tag used by Julia in the Union{Nothing, ...} field
+        _size, _alignment = _align(_size, _alignment, Int8(1), Int8(1))
+        _size, _alignment = _align(_size, _alignment, bits_size, bits_alignment)
+    end
+    if any_ptrs
+        # The tag used by Julia in the Union{Nothing, ...} field
+        _size, _alignment = _align(_size, _alignment, Int8(1), Int8(1))
+        _size, _alignment = _align(_size, _alignment, ptrs_size, ptrs_alignment)
+    end
+
+    out = TypeInfo(true, !any_ptrs, _size, _alignment)
+    return out
+end
+
+function query_typeinfo!(t::MessageType, ctx)
+    tinfo = t.tinfo[]
+    if !tinfo.known
+        if t.is_self_referential[]
+            tinfo = BOXED
+        else
+            _alignment = Int8(0)
+            _size = Int8(0)
+            _isbits = !t.is_self_referential[] # && !appears_in_cycle
+            for f in t.fields
+                f_tinfo = query_typeinfo!(f, ctx)
+                _isbits &= f_tinfo.isbits
+                _size, _alignment = _align(_size, _alignment, f_tinfo.size, f_tinfo.alignment)
+            end
+            tinfo = TypeInfo(true, _isbits, _size, _alignment)
+        end
+
+        t.tinfo[] = tinfo
+    end
+    return tinfo
+end

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -74,7 +74,7 @@ end
 
 function jl_typename(t::OneOfType, ctx::Context)
     if ctx.options.tagged_oneofs
-        name = string("var\"", ctx._toplevel_raw_name[], ".", replace(titlecase(t.name), "_"=>""), "\"")
+        name = jl_tagged_type_name(t, ctx)
     else
         name = string("OneOf{", _jl_oneof_inner_typename(t, ctx), "}")
     end
@@ -119,35 +119,47 @@ function types_needing_params(cyclical_names::AbstractVector{String}, proto_file
     return field_types_requiring_type_params
 end
 
-_types_needing_params!(out, lookup, t::AbstractProtoType,         _cyclical_set, options, self_name, _seen) = nothing
+_any(f, x) = mapreduce(f, |, x, init=false)::Bool
+_types_needing_params!(out, lookup, t::AbstractProtoType,         _cyclical_set, options, self_name, _seen) = false
 _types_needing_params!(out, lookup, t::FieldType{ReferencedType}, _cyclical_set, options, self_name, _seen) = _types_needing_params!(out, lookup, t.type, _cyclical_set, options, self_name, _seen)
-_types_needing_params!(out, lookup, t::MessageType,               _cyclical_set, options, self_name, _seen) = foreach(f->_types_needing_params!(out, lookup, f, _cyclical_set, options, self_name, _seen), t.fields)
-_types_needing_params!(out, lookup, t::GroupType,                 _cyclical_set, options, self_name, _seen) = foreach(f->_types_needing_params!(out, lookup, f, _cyclical_set, options, self_name, _seen), t.type.fields)
+_types_needing_params!(out, lookup, t::MessageType,               _cyclical_set, options, self_name, _seen) = _any(f->_types_needing_params!(out, lookup, f, _cyclical_set, options, self_name, _seen), t.fields)
+_types_needing_params!(out, lookup, t::GroupType,                 _cyclical_set, options, self_name, _seen) = _any(f->_types_needing_params!(out, lookup, f, _cyclical_set, options, self_name, _seen), t.type.fields)
 _types_needing_params!(out, lookup, t::FieldType{MapType},        _cyclical_set, options, self_name, _seen) = _types_needing_params!(out, lookup, t.type.valuetype, _cyclical_set, options, self_name, _seen)
 function _types_needing_params!(out, lookup, t::OneOfType, _cyclical_set, options, self_name, _seen)
+    found = false
     if options.parametrize_oneofs
+        found = true
         get!(_seen.dict, (true, t.name)) do
             push!(out, (true, t.name))
             return nothing
         end
     else
-        foreach(f->_types_needing_params!(out, lookup, f.type, _cyclical_set, options, self_name, _seen), t.fields)
+        found = _any(f->_types_needing_params!(out, lookup, f.type, _cyclical_set, options, self_name, _seen), t.fields)
+        if found && options.tagged_oneofs
+            get!(_seen.dict, (true, t.name)) do
+                push!(out, (true, t.name))
+                return nothing
+            end
+        end
     end
+    return found
 end
 function _types_needing_params!(out, lookup, t::ReferencedType, _cyclical_set, options, self_name, _seen)
     __types_needing_params!(out, lookup, t.name, _cyclical_set, options, self_name, _seen)
 end
 function __types_needing_params!(out, lookup, tname, _cyclical_set, options, self_name, _seen)
-    tname == self_name && return nothing # self-references do not need type params, they just work
+    tname == self_name && return false # self-references do not need type params, they just work
+    found = false
     if tname in _cyclical_set
+        found = true
         get!(_seen.dict, (false, tname)) do
             push!(out, (false, tname))
             return nothing
         end
     elseif tname in keys(lookup)
-        foreach(f->__types_needing_params!(out, lookup, f[2], _cyclical_set, options, self_name, _seen), lookup[tname])
+        found = _any(f->__types_needing_params!(out, lookup, f[2], _cyclical_set, options, self_name, _seen), lookup[tname])
     end
-    return nothing
+    return found
 end
 
 function _maybe_subtype(name, options)
@@ -168,6 +180,9 @@ const EMPTY_TYPE_PARAMS = TypeParams(Dict{String,ParamMetadata}(), Dict{String,P
 # Type bounds used in parametrizations -- for OneOfs we're constructing the union type, for
 # the other cases we're only referring to predeclared abstract types.
 function _get_oneof_type_bound(f::OneOfType, ctx::Context, type_params::TypeParams=EMPTY_TYPE_PARAMS)
+    if ctx.options.tagged_oneofs
+        return abstract_tagged_oneof_type_name(f, ctx)
+    end
     seen = Set{String}()
     union_types = String[]
     struct_name = ctx._toplevel_raw_name[]
@@ -280,9 +295,7 @@ end
 # complicate things further by also parametrizing on stub types to resolve dependency cycles.
 function reconstruct_parametrized_stub_type_name(t::Union{MessageType,ReferencedType}, ctx::Context, type_params::TypeParams=EMPTY_TYPE_PARAMS)
     type_name = t.name
-    _types_and_oneofs_requiring_type_params = ctx._types_and_oneofs_requiring_type_params
-    _remaining_cyclic_defs = ctx._remaining_cyclic_defs
-    deps = get(_types_and_oneofs_requiring_type_params, type_name, nothing)
+    deps = get(ctx._types_and_oneofs_requiring_type_params, type_name, nothing)
     # If there are no dependencies requiring type params, this means that the type is not cyclic
     # and doesn't have a parametrized oneof fields.
     isnothing(deps) && return _safename(type_name)
@@ -295,29 +308,31 @@ function reconstruct_parametrized_stub_type_name(t::Union{MessageType,Referenced
     io = IOBuffer()
     print(io, stub_type_name(type_name))
     print(io, "{")
-    _reconstruct_parametrized_stub_type_name(io, t.name, _types_and_oneofs_requiring_type_params, _remaining_cyclic_defs, type_params)
+    _reconstruct_parametrized_stub_type_name(io, t.name, ctx, type_params)
     print(io, "}")
 
     return String(take!(io))
 end
 
-function _reconstruct_parametrized_stub_type_name(io, name::String, _types_and_oneofs_requiring_type_params, _remaining_cyclic_defs, type_params=EMPTY_TYPE_PARAMS)
-    @assert name in keys(_types_and_oneofs_requiring_type_params)
-    deps = _types_and_oneofs_requiring_type_params[name]
+function _reconstruct_parametrized_stub_type_name(io, name::String, ctx, type_params=EMPTY_TYPE_PARAMS)
+    @assert name in keys(ctx._types_and_oneofs_requiring_type_params)
+    deps = ctx._types_and_oneofs_requiring_type_params[name]
     _first = true
-    for (isoneof, dep) in deps
+    for (_isoneof, dep) in deps
         !_first && print(io, ',')
-        if dep in _remaining_cyclic_defs                            # dep not defined yet -> use type param
+        if dep in ctx._remaining_cyclic_defs                            # dep not defined yet -> use type param
             print(io, type_params.references[dep].param)
-        elseif dep in keys(_types_and_oneofs_requiring_type_params) # dep is cyclic -> use stubbed name and recurse
-            dep_has_params = !isempty(_types_and_oneofs_requiring_type_params[dep])
+        elseif dep in keys(ctx._types_and_oneofs_requiring_type_params) # dep is cyclic -> use stubbed name and recurse
+            dep_has_params = !isempty(ctx._types_and_oneofs_requiring_type_params[dep])
             if dep_has_params
                 print(io, stub_type_name(dep), "{")
-                _reconstruct_parametrized_stub_type_name(io, dep, _types_and_oneofs_requiring_type_params, _remaining_cyclic_defs, type_params)
+                _reconstruct_parametrized_stub_type_name(io, dep, ctx, type_params)
                 print(io, '}')
             else
                 print(io, stub_type_name(dep))
             end
+        elseif ctx.options.tagged_oneofs
+            print(io, jl_tagged_type_name(dep, name))
         else
             print(io, "<:Union{Nothing,<:OneOf}")
         end

--- a/src/codegen/types.jl
+++ b/src/codegen/types.jl
@@ -73,7 +73,12 @@ function jl_typename(t::ReferencedType, ctx::Context)
 end
 
 function jl_typename(t::OneOfType, ctx::Context)
-    return string("OneOf{", _jl_oneof_inner_typename(t, ctx), "}")
+    if ctx.options.tagged_oneofs
+        name = string("var\"", ctx._toplevel_raw_name[], ".", replace(titlecase(t.name), "_"=>""), "\"")
+    else
+        name = string("OneOf{", _jl_oneof_inner_typename(t, ctx), "}")
+    end
+    return name
 end
 
 function _jl_oneof_inner_typename(t::OneOfType, ctx::Context)

--- a/src/parsing/proto_types.jl
+++ b/src/parsing/proto_types.jl
@@ -65,6 +65,7 @@ end
 _dot_join(prefix, s) = isempty(prefix) ? s : string(prefix, '.', s)
 
 @enum(FieldLabel, DEFAULT, REQUIRED, OPTIONAL, REPEATED)
+@enum(IsbitsInfo, UNKNOWN, ISBITS, NONISBITS)
 
 # We're reusing the same FieldType for both Message and OneOf fields
 # OneOf fields don't use the label field
@@ -97,6 +98,7 @@ struct MessageType <: AbstractProtoType
     extends::Vector{ExtendType}
     has_oneof_field::Bool
     is_self_referential::Base.RefValue{Bool}
+    isbits::Base.RefValue{IsbitsInfo}
 end
 
 struct GroupType <: AbstractProtoFieldType
@@ -343,6 +345,7 @@ function _parse_message_body(ps::ParserState, name, definitions, name_prefix)
     extends = Vector{ExtendType}()
     has_oneof_field = false
     is_self_referential = Ref{Bool}(false) # set during topological sort
+    isbits = Ref{IsbitsInfo}(UNKNOWN) # set during tagged-oneof generation
 
     name = _dot_join(name_prefix, name)
     expectnext(ps, Tokens.LBRACE)
@@ -379,7 +382,7 @@ function _parse_message_body(ps::ParserState, name, definitions, name_prefix)
         end
     end
     # TODO: validate field_numbers vs reserved and extensions
-    return MessageType(name, fields, options, reserved_nums, reserved_names, extensions, extends, has_oneof_field, is_self_referential)
+    return MessageType(name, fields, options, reserved_nums, reserved_names, extensions, extends, has_oneof_field, is_self_referential, isbits)
 end
 
 # We consumed RPC

--- a/src/parsing/proto_types.jl
+++ b/src/parsing/proto_types.jl
@@ -1,3 +1,13 @@
+struct TypeInfo
+    known::Bool # False when initilized inside of MessageType
+    isbits::Bool
+    size::UInt8
+    alignment::UInt8
+end
+function Base.show(io::IO, ti::TypeInfo)
+    println(io, "TypeInfo(", ti.known, ", ", ti.isbits, ", ", Int(ti.size), ", ", Int(ti.alignment), ")")
+    return nothing
+end
 abstract type AbstractProtoType end
 abstract type AbstractProtoNumericType <: AbstractProtoType end
 abstract type AbstractProtoFixedType <: AbstractProtoNumericType end
@@ -65,7 +75,6 @@ end
 _dot_join(prefix, s) = isempty(prefix) ? s : string(prefix, '.', s)
 
 @enum(FieldLabel, DEFAULT, REQUIRED, OPTIONAL, REPEATED)
-@enum(IsbitsInfo, UNKNOWN, ISBITS, NONISBITS)
 
 # We're reusing the same FieldType for both Message and OneOf fields
 # OneOf fields don't use the label field
@@ -98,7 +107,7 @@ struct MessageType <: AbstractProtoType
     extends::Vector{ExtendType}
     has_oneof_field::Bool
     is_self_referential::Base.RefValue{Bool}
-    isbits::Base.RefValue{IsbitsInfo}
+    tinfo::Base.RefValue{TypeInfo}
 end
 
 struct GroupType <: AbstractProtoFieldType
@@ -345,7 +354,7 @@ function _parse_message_body(ps::ParserState, name, definitions, name_prefix)
     extends = Vector{ExtendType}()
     has_oneof_field = false
     is_self_referential = Ref{Bool}(false) # set during topological sort
-    isbits = Ref{IsbitsInfo}(UNKNOWN) # set during tagged-oneof generation
+    isbits = Ref(TypeInfo(false, false, 0, 0)) # set during tagged-oneof generation
 
     name = _dot_join(name_prefix, name)
     expectnext(ps, Tokens.LBRACE)


### PR DESCRIPTION
WIP

The idea is to generate a custom struct for each `oneof` field which would contain a tag and logic to access the active union member in a type-stable way with `PB.active_value(x) do val; ...; end`

Example:
```protobuf
syntax = "proto3";
message A { oneof field_name { string b = 3; uint64 c = 4; bytes d = 5; int32 e = 6; int32 g = 7; } }
```

```julia
struct var"A.FieldName" <: PB.TaggedOneOf
    tag::UInt8
    bit::Union{Nothing,UInt64,Int32}
    ptr::Union{Nothing,String,Vector{UInt8}}
end
var"A.FieldName"(::Val{:b}, x) = var"A.FieldName"(UInt8(1), nothing, convert(String, x))
var"A.FieldName"(::Val{:c}, x) = var"A.FieldName"(UInt8(2), convert(UInt64, x), nothing)
var"A.FieldName"(::Val{:d}, x) = var"A.FieldName"(UInt8(3), nothing, convert(Vector{UInt8}, x))
var"A.FieldName"(::Val{:e}, x) = var"A.FieldName"(UInt8(4), convert(Int32, x), nothing)
var"A.FieldName"(::Val{:g}, x) = var"A.FieldName"(UInt8(5), convert(Int32, x), nothing)
PB.unsafe_getproperty(x::var"A.FieldName", ::Val{:b}) = Base.getfield(x, :ptr)::String
PB.unsafe_getproperty(x::var"A.FieldName", ::Val{:c}) = Base.getfield(x, :bit)::UInt64
PB.unsafe_getproperty(x::var"A.FieldName", ::Val{:d}) = Base.getfield(x, :ptr)::Vector{UInt8}
PB.unsafe_getproperty(x::var"A.FieldName", ::Val{:e}) = Base.getfield(x, :bit)::Int32
PB.unsafe_getproperty(x::var"A.FieldName", ::Val{:g}) = Base.getfield(x, :bit)::Int32
PB.field_to_tag(::Type{var"A.FieldName"}) = (;b = UInt8(1), c = UInt8(2), d = UInt8(3), e = UInt8(4), g = UInt8(5))
function PB.active_name(f::F, x::var"A.FieldName") where {F}
    tag = getfield(x, :tag)
    if     tag == UInt8(1); return f(Val(:b))
    elseif tag == UInt8(2); return f(Val(:c))
    elseif tag == UInt8(3); return f(Val(:d))
    elseif tag == UInt8(4); return f(Val(:e))
    elseif tag == UInt8(5); return f(Val(:g))
    else   PB.throw_bad_tag(var"A.FieldName", tag)
    end
end
function PB.active_value(f::F, x::var"A.FieldName") where {F}
    tag = getfield(x, :tag)
    if     tag == UInt8(1); return f(Base.getfield(x, :ptr)::String)
    elseif tag == UInt8(2); return f(Base.getfield(x, :bit)::UInt64)
    elseif tag == UInt8(3); return f(Base.getfield(x, :ptr)::Vector{UInt8})
    elseif tag == UInt8(4); return f(Base.getfield(x, :bit)::Int32)
    elseif tag == UInt8(5); return f(Base.getfield(x, :bit)::Int32)
    else   PB.throw_bad_tag(var"A.FieldName", tag)
    end
end

struct A
    field_name::var"A.FieldName"
end
# ...
```

A big remaining todo is handling dependency cycles.