### PR TITLE
Honor proto3 explicit `optional` for scalar fields

### DIFF
--- a/src/codegen/defaults.jl
+++ b/src/codegen/defaults.jl
@@ -23,12 +23,37 @@ function _is_optional_referenced_message(field::Union{FieldType{ReferencedType},
     return false
 end
 
+# proto3 explicit `optional` on a scalar field carries presence semantics
+# (synthetic oneof at the descriptor level). We surface that in Julia by typing
+# the field as `Union{Nothing,T}` and defaulting it to `nothing` so that
+# unset and zero-valued fields are distinguishable. proto2 behavior is left
+# untouched (its OPTIONAL label is the default-ish presence-less label there).
+_is_scalar_proto_type(::AbstractProtoType) = false
+_is_scalar_proto_type(::Union{StringType,BytesType,BoolType}) = true
+_is_scalar_proto_type(::AbstractProtoFloatType) = true
+_is_scalar_proto_type(::AbstractProtoNumericType) = true
+function _is_proto3_optional_scalar(@nospecialize(field), ctx::Context)
+    field isa FieldType || return false
+    ctx.proto_file.preamble.isproto3 || return false
+    field.label === Parsers.OPTIONAL || return false
+    _is_scalar_proto_type(field.type) || return false
+    struct_name = ctx._toplevel_raw_name[]
+    return !_should_force_required(string(struct_name, ".", jl_fieldname(field)), ctx)
+end
+
 _needs_encoding_condition(field::Union{FieldType{ReferencedType},GroupType}, ctx::Context) = field.label === Parsers.REPEATED || _is_optional_referenced_message(field, ctx)
 _needs_encoding_condition(field::FieldType, _::Context) = field.label !== Parsers.REQUIRED
 
-jl_type_default_value(f::FieldType{StringType}, ::Context) = get(f.options, "default", "\"\"")
-jl_type_default_value(f::FieldType{BoolType}, ::Context)   = get(f.options, "default", "false")
+function jl_type_default_value(f::FieldType{StringType}, ctx::Context)
+    _is_proto3_optional_scalar(f, ctx) && return "nothing"
+    return get(f.options, "default", "\"\"")
+end
+function jl_type_default_value(f::FieldType{BoolType}, ctx::Context)
+    _is_proto3_optional_scalar(f, ctx) && return "nothing"
+    return get(f.options, "default", "false")
+end
 function jl_type_default_value(@nospecialize(f::FieldType{<:AbstractProtoFloatType}), ctx::Context)
+    _is_proto3_optional_scalar(f, ctx) && return "nothing"
     type_name = jl_typename(f, ctx)
     default = get(f.options, "default", nothing)
     if default === nothing
@@ -55,6 +80,7 @@ _jl_parse_default_int(::Union{Int64Type,SInt64Type,SFixed64Type}, s::String) = p
 _jl_parse_default_int(::Union{UInt32Type,Fixed32Type}, s::String) = parse(UInt32, s)
 _jl_parse_default_int(::Union{UInt64Type,Fixed64Type}, s::String) = parse(UInt64, s)
 function jl_type_default_value(@nospecialize(f::FieldType{<:AbstractProtoNumericType}), ctx::Context)
+    _is_proto3_optional_scalar(f, ctx) && return "nothing"
     type_name = jl_typename(f, ctx)
     default = get(f.options, "default", nothing)
     if default === nothing
@@ -62,7 +88,8 @@ function jl_type_default_value(@nospecialize(f::FieldType{<:AbstractProtoNumeric
     end
     return string(type_name, '(', repr(_jl_parse_default_int(f.type, default)), ')')
 end
-function jl_type_default_value(f::FieldType{BytesType}, ::Context)
+function jl_type_default_value(f::FieldType{BytesType}, ctx::Context)
+    _is_proto3_optional_scalar(f, ctx) && return "nothing"
     out = get(f.options, "default", nothing)
     return isnothing(out) ? "UInt8[]" : "b$(out)"
 end

--- a/src/codegen/encode_methods.jl
+++ b/src/codegen/encode_methods.jl
@@ -5,10 +5,17 @@ function encode_condition(f::FieldType, ctx::Context)
         return _encode_condition(f, ctx)
     end
 end
-_encode_condition(@nospecialize(f::FieldType), ctx::Context) = "x.$(jl_fieldname(f)) != $(jl_init_value(f, ctx))"
-_encode_condition(f::FieldType{<:AbstractProtoFloatType}, ctx:: Context) = "x.$(jl_fieldname(f)) !== $(jl_init_value(f, ctx))"
+function _encode_condition(@nospecialize(f::FieldType), ctx::Context)
+    _is_proto3_optional_scalar(f, ctx) && return "!isnothing(x.$(jl_fieldname(f)))"
+    return "x.$(jl_fieldname(f)) != $(jl_init_value(f, ctx))"
+end
+function _encode_condition(f::FieldType{<:AbstractProtoFloatType}, ctx::Context)
+    _is_proto3_optional_scalar(f, ctx) && return "!isnothing(x.$(jl_fieldname(f)))"
+    return "x.$(jl_fieldname(f)) !== $(jl_init_value(f, ctx))"
+end
 _encode_condition(f::FieldType{<:MapType}, ::Context) = "!isempty(x.$(jl_fieldname(f)))"
 function _encode_condition(f::FieldType{T}, ctx::Context) where {T<:Union{StringType,BytesType}}
+    _is_proto3_optional_scalar(f, ctx) && return "!isnothing(x.$(jl_fieldname(f)))"
     default = get(f.options, "default", nothing)
     if default === nothing
         return "!isempty(x.$(jl_fieldname(f)))"

--- a/src/codegen/toplevel_definitions.jl
+++ b/src/codegen/toplevel_definitions.jl
@@ -6,7 +6,11 @@ function _should_force_required(qualified_name, ctx::Context)
 end
 
 function generate_struct_field(io, @nospecialize(field), ctx::Context, type_params)
-    println(io, "    ", jl_fieldname(field)::String, "::", jl_typename(field, ctx)::String)
+    type_name = jl_typename(field, ctx)::String
+    if _is_proto3_optional_scalar(field, ctx)
+        type_name = string("Union{Nothing,", type_name, "}")
+    end
+    println(io, "    ", jl_fieldname(field)::String, "::", type_name)
 end
 
 function generate_struct_field(io, field::FieldType{ReferencedType}, ctx::Context, type_params::TypeParams)

--- a/test/test_codegen.jl
+++ b/test/test_codegen.jl
@@ -1033,10 +1033,13 @@ end
             }
             message B {}
             """)
+            # proto3 explicit `optional` carries presence: scalar fields become
+            # Union{Nothing,T} with `nothing` defaults, mirroring how messages
+            # are already handled.
             @test contains(s, """
             struct A
                 def_int::Int32
-                opt_int::Int32
+                opt_int::Union{Nothing,Int32}
                 rep_int::Vector{Int32}
                 def_msg::Union{Nothing,B}
                 opt_msg::Union{Nothing,B}
@@ -1047,7 +1050,7 @@ end
             function PB.encode(e::PB.AbstractProtoEncoder, x::A)
                 initpos = position(e.io)
                 x.def_int != zero(Int32) && PB.encode(e, 1, x.def_int)
-                x.opt_int != zero(Int32) && PB.encode(e, 2, x.opt_int)
+                !isnothing(x.opt_int) && PB.encode(e, 2, x.opt_int)
                 !isempty(x.rep_int) && PB.encode(e, 3, x.rep_int)
                 !isnothing(x.def_msg) && PB.encode(e, 4, x.def_msg)
                 !isnothing(x.opt_msg) && PB.encode(e, 5, x.opt_msg)
@@ -1057,7 +1060,7 @@ end
             function PB._encoded_size(x::A)
                 encoded_size = 0
                 x.def_int != zero(Int32) && (encoded_size += PB._encoded_size(x.def_int, 1))
-                x.opt_int != zero(Int32) && (encoded_size += PB._encoded_size(x.opt_int, 2))
+                !isnothing(x.opt_int) && (encoded_size += PB._encoded_size(x.opt_int, 2))
                 !isempty(x.rep_int) && (encoded_size += PB._encoded_size(x.rep_int, 3))
                 !isnothing(x.def_msg) && (encoded_size += PB._encoded_size(x.def_msg, 4))
                 !isnothing(x.opt_msg) && (encoded_size += PB._encoded_size(x.opt_msg, 5))
@@ -1065,6 +1068,36 @@ end
                 return encoded_size
             end
             """)
+        end
+
+        @testset "proto3 `optional` scalars get Union{Nothing,T} with `nothing` defaults" begin
+            # All scalar kinds: type wrap and default both flip when proto3 + optional.
+            for (proto_type, jl_type) in [
+                ("bool", "Bool"),
+                ("int32", "Int32"), ("int64", "Int64"),
+                ("uint32", "UInt32"), ("uint64", "UInt64"),
+                ("sint32", "Int32"), ("sint64", "Int64"),
+                ("fixed32", "UInt32"), ("fixed64", "UInt64"),
+                ("sfixed32", "Int32"), ("sfixed64", "Int64"),
+                ("float", "Float32"), ("double", "Float64"),
+                ("string", "String"), ("bytes", "Vector{UInt8}"),
+            ]
+                s, p, ctx = translate_simple_proto("syntax = \"proto3\"; message A { optional $proto_type a = 1; }")
+                @test contains(s, "a::Union{Nothing,$jl_type}\n")
+                @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "nothing"
+                # Encode condition flips to !isnothing regardless of any trailing Val{...} markers (zigzag/fixed).
+                @test contains(s, "!isnothing(x.a) && PB.encode(e, 1, x.a")
+            end
+
+            # proto3 implicit-presence (no `optional` keyword) keeps the bare type and zero default.
+            s, p, ctx = translate_simple_proto("syntax = \"proto3\"; message A { int32 a = 1; }")
+            @test contains(s, "a::Int32\n")
+            @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
+
+            # proto2 OPTIONAL stays unchanged (presence-less default-valued semantics).
+            s, p, ctx = translate_simple_proto("syntax = \"proto2\"; message A { optional int32 a = 1; }")
+            @test contains(s, "a::Int32\n")
+            @test CodeGenerators.jl_default_value(p.definitions["A"].fields[1], ctx) == "zero(Int32)"
         end
 
         s, p, ctx = translate_simple_proto("message A { optional string a = 1; }")


### PR DESCRIPTION
Addresses #293 (proto3 case).

proto3 `optional` scalars now generate `Union{Nothing,T}` with `nothing` defaults, matching how messages are already handled and giving them the explicit-presence semantics the spec requires. As a side effect, an explicit `optional int32 a = 1` set to `0` now correctly hits the wire (it was silently dropped before).

```julia
# syntax = "proto3"; message A { optional int32 a = 1; }
struct A
    a::Union{Nothing,Int32}
end
# encode: !isnothing(x.a) && PB.encode(e, 1, x.a)
```

Happy to extend to proto2 OPTIONAL and tidy the helper-call repetition if that direction is desired.