### PR TITLE
Fix submodule include ordering for transitive sibling dependencies

### DIFF
--- a/src/codegen/modules.jl
+++ b/src/codegen/modules.jl
@@ -164,29 +164,16 @@ function generate_module_file(io::IO, m::ProtoModule, output_directory::Abstract
         end
     end
     has_deps && println(io)
-    # Load in imported proto files that are defined in this package (the files ending with `_pb.jl`)
-    # In case there is a dependency of some of these files on a submodule, we include that submodule
-    # first.
-    seen = Set{String}()
-    for file in m.proto_files
-        for i in import_paths(file)
-            imported_file = parsed_files[i]
-            if length(namespace(file)) == length(namespace(imported_file)) - 1 && _startswith(namespace(file), namespace(imported_file))
-                submodule_name = last(namespace(imported_file))
-                get!(seen.dict, submodule_name) do
-                    println(io, "include(", _include_stmt_format(joinpath(submodule_name, string(submodule_name, ".jl"))), ")")
-                end
-            end
-        end
-        println(io, "include(", _include_stmt_format(proto_script_name(file)), ")")
-    end
-    # Load in submodules nested in this namespace (the modules ending with `PB`),
-    # that is, if we didn't include them above.
+    # Include ALL submodules in topologically sorted order first, then proto files.
+    # This ensures inter-sibling submodule dependencies are resolved before any
+    # proto file or submodule that references them. This is safe because proto files
+    # can depend on submodules but never the reverse.
     for submodule_namespace in submodule_namespaces
         submodule = m.submodules[submodule_namespace]
-        get!(seen.dict, submodule.name) do
-            println(io, "include(", _include_stmt_format(joinpath(submodule.name, string(submodule.name, ".jl"))), ")")
-        end
+        println(io, "include(", _include_stmt_format(joinpath(submodule.name, string(submodule.name, ".jl"))), ")")
+    end
+    for file in m.proto_files
+        println(io, "include(", _include_stmt_format(proto_script_name(file)), ")")
     end
     println(io)
     println(io, "end # module $(m.name)")

--- a/test/test_modules.jl
+++ b/test/test_modules.jl
@@ -193,6 +193,36 @@ end
     @test n.packages["A"].submodules[["A", "B"]].name == "B"
 end
 
+@testset "Submodules with transitive sibling dependencies are included before proto files" begin
+    # Regression test: when a proto file at the parent level imports a child
+    # submodule B, and B imports sibling submodule A, the old two-phase include
+    # strategy would:
+    #   1. Include B (direct import of root proto file) + root proto file
+    #   2. Include A in the "remaining" phase — AFTER B
+    # This breaks because B depends on A but A wasn't loaded yet.
+    # The fix includes ALL submodules in topological order first, then proto files.
+    s, d, n = simple_namespace_from_protos(
+        """package P; import "sibling_b";""",
+        Dict(
+            "sibling_b" => """package P.B; import "sibling_a";""",
+            "sibling_a" => """package P.A;""",
+        ),
+        "P"
+    );
+    # A must appear before B (B depends on A), and both before proto files
+    @test s == """
+    module P
+
+    import .P as var"#P"
+
+    include("A/A.jl")
+    include("B/B.jl")
+    include("main_pb.jl")
+
+    end # module P
+    """
+end
+
 @testset "Imports within a leaf module which name-clashes with top module" begin
     s, d, n = simple_namespace_from_protos(
         """
@@ -212,8 +242,8 @@ end
 
     import .A as var"#A"
 
-    include("main_pb.jl")
     include("B/B.jl")
+    include("main_pb.jl")
 
     end # module A
     """


### PR DESCRIPTION
## Problem
When generating Julia module files, `generate_module_file()` used a two-phase
strategy to determine include order:
1. For each proto file, scan its direct imports for child submodules, include those first
2. Append remaining submodules at the end

This broke when submodule B depended on sibling submodule A, but A wasn't
directly imported by any proto file at the parent level — only transitively
through B. The result was B being included before A, causing `UndefVarError`
at load time.

## Fix
Include ALL submodules in topologically sorted order first, then all proto files.
This is safe because proto files can depend on submodules but submodules never
depend on parent-level proto files (enforced by protobuf semantics).

## Impact
- Fixes `UndefVarError` for transitive sibling submodule dependencies
- Generated module files will have slightly different include ordering:
  submodules are now always listed before proto files. This is a cosmetic
  change for configurations that already worked.
- No API or behavioral changes for downstream users

## Testing
- Added regression test reproducing the exact failure scenario
- Existing test ("name-clashes with top module") updated for new ordering
- Full test suite passes
- In CI, all Julia nightly CI tests failed. This appears to be a preexisting issue affecting all recent PRs, unrelated to this PR.